### PR TITLE
Rename vectorizer None to SelfProvided

### DIFF
--- a/src/Weaviate.Client.Tests/Integration/TestBatchDelete.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestBatchDelete.cs
@@ -11,7 +11,7 @@ public partial class BatchDeleteTests : IntegrationTests
     {
         var collection = await CollectionFactory(
             properties: [Property.Text("Name")],
-            vectorConfig: new VectorConfig("default", new Vectorizer.None())
+            vectorConfig: new VectorConfig("default", new Vectorizer.SelfProvided())
         );
 
         await collection.Data.InsertMany(batcher =>
@@ -34,7 +34,7 @@ public partial class BatchDeleteTests : IntegrationTests
     {
         var collection = await CollectionFactory(
             properties: [Property.Text("Name"), Property.Int("Age")],
-            vectorConfig: new VectorConfig("default", new Vectorizer.None())
+            vectorConfig: new VectorConfig("default", new Vectorizer.SelfProvided())
         );
 
         await collection.Data.InsertMany(batcher =>
@@ -62,7 +62,7 @@ public partial class BatchDeleteTests : IntegrationTests
     {
         var collection = await CollectionFactory(
             properties: [Property.Text("Name"), Property.Int("Age")],
-            vectorConfig: new VectorConfig("default", new Vectorizer.None())
+            vectorConfig: new VectorConfig("default", new Vectorizer.SelfProvided())
         );
 
         await collection.Data.InsertMany(batcher =>
@@ -90,7 +90,7 @@ public partial class BatchDeleteTests : IntegrationTests
     public async Task Test_Dry_Run(bool dryRun)
     {
         var collection = await CollectionFactory(
-            vectorConfig: new VectorConfig("default", new Vectorizer.None())
+            vectorConfig: new VectorConfig("default", new Vectorizer.SelfProvided())
         );
 
         var uuid1 = await collection.Data.Insert(new { });
@@ -128,7 +128,7 @@ public partial class BatchDeleteTests : IntegrationTests
     public async Task Test_Verbosity(bool verbose)
     {
         var collection = await CollectionFactory(
-            vectorConfig: new VectorConfig("default", new Vectorizer.None())
+            vectorConfig: new VectorConfig("default", new Vectorizer.SelfProvided())
         );
 
         var uuid1 = await collection.Data.Insert(new { });

--- a/src/Weaviate.Client.Tests/Integration/TestCollections.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestCollections.cs
@@ -15,17 +15,17 @@ public partial class CollectionsTests : IntegrationTests
             await CollectionFactory(
                 name: "Collection1",
                 properties: [Property.Text("Name")],
-                vectorConfig: Configure.Vectors.None()
+                vectorConfig: Configure.Vectors.SelfProvided()
             ),
             await CollectionFactory(
                 name: "Collection2",
                 properties: [Property.Text("Lastname")],
-                vectorConfig: Configure.Vectors.None()
+                vectorConfig: Configure.Vectors.SelfProvided()
             ),
             await CollectionFactory(
                 name: "Collection3",
                 properties: [Property.Text("Address")],
-                vectorConfig: Configure.Vectors.None()
+                vectorConfig: Configure.Vectors.SelfProvided()
             ),
         };
 
@@ -46,7 +46,7 @@ public partial class CollectionsTests : IntegrationTests
     {
         var collection = await CollectionFactory(
             properties: [Property.Text("Name")],
-            vectorConfig: new VectorConfig("default", new Vectorizer.None())
+            vectorConfig: new VectorConfig("default", new Vectorizer.SelfProvided())
         );
 
         bool exists = await _weaviate.Collections.Exists(collection.Name);
@@ -69,7 +69,7 @@ public partial class CollectionsTests : IntegrationTests
             name: "MyOwnSuffix",
             description: "My own description too",
             properties: [Property.Text("Name")],
-            vectorConfig: new VectorConfig("default", new Vectorizer.None())
+            vectorConfig: new VectorConfig("default", new Vectorizer.SelfProvided())
         );
 
         var export = await _weaviate.Collections.Export(collection.Name);

--- a/src/Weaviate.Client.Tests/Integration/TestIterator.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestIterator.cs
@@ -9,7 +9,7 @@ public partial class BasicTests
     {
         var collection = await CollectionFactory(
             properties: [Property.Text("name")],
-            vectorConfig: new VectorConfig("default", new Vectorizer.None())
+            vectorConfig: new VectorConfig("default", new Vectorizer.SelfProvided())
         );
 
         await collection.Data.InsertMany(new { Name = "Name 1" }, new { Name = "Name 2" });
@@ -166,7 +166,7 @@ public partial class BasicTests
     {
         var collection = await CollectionFactory(
             properties: [Property.Text("this"), Property.Text("that")],
-            vectorConfig: new VectorConfig("default", new Vectorizer.None())
+            vectorConfig: new VectorConfig("default", new Vectorizer.SelfProvided())
         );
 
         var insertData = Enumerable
@@ -214,7 +214,7 @@ public partial class BasicTests
     {
         var collection = await CollectionFactory(
             properties: [Property.Int("data")],
-            vectorConfig: new VectorConfig("default", new Vectorizer.None())
+            vectorConfig: new VectorConfig("default", new Vectorizer.SelfProvided())
         );
 
         if (count > 0)
@@ -260,7 +260,7 @@ public partial class BasicTests
     {
         var collection = await CollectionFactory(
             properties: [Property.Int("data")],
-            vectorConfig: new VectorConfig("default", new Vectorizer.None())
+            vectorConfig: new VectorConfig("default", new Vectorizer.SelfProvided())
         );
 
         var insertData = Enumerable.Range(0, 10).Select(i => new { data = i }).ToArray();

--- a/src/Weaviate.Client.Tests/Integration/_Integration.cs
+++ b/src/Weaviate.Client.Tests/Integration/_Integration.cs
@@ -79,7 +79,7 @@ public abstract partial class IntegrationTests : IAsyncDisposable
 
         ArgumentException.ThrowIfNullOrEmpty(name);
 
-        // Default is VectorizerConfig.None
+        // Default is Vectorizer.SelfProvided
         vectorConfig ??= new VectorConfig("default");
 
         references ??= [];

--- a/src/Weaviate.Client.Tests/Unit/TestVectorizers.cs
+++ b/src/Weaviate.Client.Tests/Unit/TestVectorizers.cs
@@ -39,7 +39,7 @@ public partial class UnitTests
                 "location",
                 new Vectorizer.Text2VecContextionary { Properties = ["location"] }
             ),
-            new VectorConfig("nein", new Vectorizer.None()),
+            new VectorConfig("nein", new Vectorizer.SelfProvided()),
             contextionaryVectorizer.New("contextionary1", properties: ["breed"]),
             contextionaryVectorizer.New("contextionary2", properties: ["color"]),
             Configure
@@ -67,10 +67,10 @@ public partial class UnitTests
     }
 
     [Fact]
-    public void Test_NamedVectorConfig_None_Has_No_Properties()
+    public void Test_NamedVectorConfig_SelfProvided_Has_No_Properties()
     {
         // Arrange
-        var vc = new VectorConfig("default", new Vectorizer.None());
+        var vc = new VectorConfig("default", new Vectorizer.SelfProvided());
 
         // Act
         var dto = vc.Vectorizer?.ToDto() ?? default;

--- a/src/Weaviate.Client/Configure/Vectorizer.cs
+++ b/src/Weaviate.Client/Configure/Vectorizer.cs
@@ -6,7 +6,7 @@ public static partial class Configure
 {
     public static class Vectors
     {
-        public static VectorConfig None(string name = "default") => new(name);
+        public static VectorConfig SelfProvided(string name = "default") => new(name);
 
         public class VectorConfigBuilder(VectorizerConfig Config)
         {

--- a/src/Weaviate.Client/Models/VectorConfig.cs
+++ b/src/Weaviate.Client/Models/VectorConfig.cs
@@ -15,7 +15,7 @@ public record VectorConfig
     )
     {
         Name = name;
-        Vectorizer = vectorizer ?? new Vectorizer.None();
+        Vectorizer = vectorizer ?? new Vectorizer.SelfProvided();
         VectorIndexConfig = vectorIndexConfig ?? new VectorIndex.HNSW();
     }
 

--- a/src/Weaviate.Client/Models/Vectorizer.Declarations.cs
+++ b/src/Weaviate.Client/Models/Vectorizer.Declarations.cs
@@ -3,9 +3,9 @@ namespace Weaviate.Client.Models;
 public static partial class Vectorizer
 {
     // All record constructors for derived types
-    public partial record None : VectorizerConfig
+    public partial record SelfProvided : VectorizerConfig
     {
-        public None()
+        public SelfProvided()
             : base("none") { }
     }
 

--- a/src/Weaviate.Client/Models/Vectorizer.cs
+++ b/src/Weaviate.Client/Models/Vectorizer.cs
@@ -4,7 +4,7 @@ namespace Weaviate.Client.Models;
 
 public static partial class Vectorizer
 {
-    public partial record None { }
+    public partial record SelfProvided { }
 
     public partial record Img2VecNeural
     {

--- a/src/Weaviate.Client/Models/Vectorizers/Factory.cs
+++ b/src/Weaviate.Client/Models/Vectorizers/Factory.cs
@@ -10,7 +10,7 @@ internal static class VectorizerConfigFactory
 {
     private static readonly Dictionary<string, Type> _configTypes = new()
     {
-        { "none", typeof(Vectorizer.None) },
+        { "none", typeof(Vectorizer.SelfProvided) },
         { "img2vec-neural", typeof(Vectorizer.Img2VecNeural) },
         { "multi2vec-clip", typeof(Vectorizer.Multi2VecClip) },
         { "multi2vec-cohere", typeof(Vectorizer.Multi2VecCohere) },
@@ -55,7 +55,7 @@ internal static class VectorizerConfigFactory
 
         if (type == "none")
         {
-            return new Vectorizer.None();
+            return new Vectorizer.SelfProvided();
         }
 
         try


### PR DESCRIPTION
Update the vectorizer configuration to replace instances of `None` with `SelfProvided`, reflecting a more accurate representation of the intended functionality.