### PR TITLE
Remove NotEqual assertion in integration tests

### DIFF
--- a/src/Weaviate.Client.Tests/Integration/TestCollections.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestCollections.cs
@@ -1025,12 +1025,8 @@ public partial class CollectionsTests : IntegrationTests
         Assert.True(results.All(r => r.RerankScore == null));
         Assert.True(resultsReranked.All(r => r.RerankScore != null));
 
-        var resultsIDs = results.Select(x => x.ID).ToList();
+        var resultsIDs = results.OrderByDescending(x => x.Age).Select(x => x.ID).ToList();
         var resultsRerankedIDs = resultsReranked.Select(x => x.ID).ToList();
-
-        Assert.NotEqual(resultsIDs, resultsRerankedIDs);
-
-        resultsIDs = results.OrderByDescending(x => x.Age).Select(x => x.ID).ToList();
 
         Assert.Equal(resultsIDs, resultsRerankedIDs);
     }


### PR DESCRIPTION
Eliminate the NotEqual assertion due to the uncertainty of result order, ensuring tests focus on expected equality instead.