### PR TITLE
Rename MetadataOptions.Full to MetadataOptions.All

### DIFF
--- a/src/Weaviate.Client.Tests/Integration/TestIterator.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestIterator.cs
@@ -74,7 +74,7 @@ public partial class BasicTests
         MetadataQuery? metadata = null;
         if (includeVector && returnFullMetadata == true)
         {
-            metadata = new MetadataQuery(MetadataOptions.Full | MetadataOptions.Vector);
+            metadata = new MetadataQuery(MetadataOptions.All | MetadataOptions.Vector);
         }
         else if (includeVector)
         {
@@ -82,7 +82,7 @@ public partial class BasicTests
         }
         else if (returnFullMetadata == true)
         {
-            metadata = new MetadataQuery(MetadataOptions.Full);
+            metadata = new MetadataQuery(MetadataOptions.All);
         }
 
         // Build fields array

--- a/src/Weaviate.Client.Tests/Integration/TestSearchHybrid.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestSearchHybrid.cs
@@ -217,7 +217,7 @@ public partial class SearchTests : IntegrationTests
                 (VectorData<float>)obj.Vectors["default"],
                 Distance: Convert.ToSingle(nearVec.First().Metadata.Distance!.Value + 0.001)
             ),
-            returnMetadata: MetadataOptions.Full
+            returnMetadata: MetadataOptions.All
         );
 
         Assert.Equal(uuidBanana, hybridObjs2.First().ID);
@@ -277,7 +277,7 @@ public partial class SearchTests : IntegrationTests
                     Distance: Convert.ToSingle(nearVec.First().Metadata.Distance!.Value + 0.001)
                 ),
                 targetVector: ["text"],
-                returnMetadata: MetadataOptions.Full
+                returnMetadata: MetadataOptions.All
             )
         ).Objects;
 
@@ -316,7 +316,7 @@ public partial class SearchTests : IntegrationTests
                     MoveTo: new Move(force: 0.1f, concepts: ["pudding"]),
                     MoveAway: new Move(force: 0.1f, concepts: ["smoothie"])
                 ),
-                returnMetadata: MetadataOptions.Full
+                returnMetadata: MetadataOptions.All
             )
         ).Objects;
 
@@ -360,7 +360,7 @@ public partial class SearchTests : IntegrationTests
                     MoveAway: new Move(force: 0.1f, concepts: ["smoothie"])
                 ),
                 targetVector: ["text"],
-                returnMetadata: MetadataOptions.Full
+                returnMetadata: MetadataOptions.All
             )
         ).Objects;
 

--- a/src/Weaviate.Client/Models/MetadataQuery.cs
+++ b/src/Weaviate.Client/Models/MetadataQuery.cs
@@ -12,7 +12,7 @@ public enum MetadataOptions
     Score = 1 << 5, // 2^5
     ExplainScore = 1 << 6, // 2^6
     IsConsistent = 1 << 7, // 2^7
-    Full =
+    All =
         CreationTime | LastUpdateTime | Distance | Certainty | Score | ExplainScore | IsConsistent,
 }
 


### PR DESCRIPTION
Update the enumeration for metadata options to improve clarity and consistency in the codebase. Adjust related test cases to reflect this change.

Resolves #111 