### PR TITLE
Add AllOf and AnyOf methods to Filter for combined filtering operations

### DIFF
--- a/src/Weaviate.Client.Tests/Unit/TestFilters.cs
+++ b/src/Weaviate.Client.Tests/Unit/TestFilters.cs
@@ -173,4 +173,23 @@ public partial class FilterTests
         // Assert
         Assert.Equal(expected, f.InternalFilter);
     }
+
+    [Fact]
+    public void Filter_AllOf_And_AnyOf()
+    {
+        var uuid2 = Guid.NewGuid();
+        var f1 = Filter.Property("uuids").ContainsAny(new[] { uuid2 });
+        var f2 = Filter.Property("name").Length().Equal(5);
+
+        var expectedAllOf = f1 & f2;
+        var expectedAnyOf = f1 | f2;
+
+        // Act
+        var fAllOf = Filter.AllOf(f1, f2);
+        var fAnyOf = Filter.AnyOf(f1, f2);
+
+        // Assert
+        Assert.Equal(expectedAllOf.InternalFilter, fAllOf.InternalFilter);
+        Assert.Equal(expectedAnyOf.InternalFilter, fAnyOf.InternalFilter);
+    }
 }

--- a/src/Weaviate.Client/Models/Filter.cs
+++ b/src/Weaviate.Client/Models/Filter.cs
@@ -187,6 +187,10 @@ public partial record Filter
         return this;
     }
 
+    internal static Filter AllOf(params Filter[] filters) => And(filters);
+
+    internal static Filter AnyOf(params Filter[] filters) => Or(filters);
+
     #region Operators
     public static Filter operator &(Filter left, Filter right)
     {


### PR DESCRIPTION
Introduce AllOf and AnyOf methods to enable combined filtering operations in the Filter class, enhancing the flexibility of filter creation. Add corresponding unit tests to validate the functionality.

Resolves #118 