### PR TITLE
Change Properties and References From List to Array

### DIFF
--- a/src/Weaviate.Client.Tests/Integration/TestCollections.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestCollections.cs
@@ -302,7 +302,7 @@ public partial class CollectionsTests : IntegrationTests
 
         // Properties validation
         Assert.NotNull(export.Properties);
-        Assert.Equal(2, export.Properties.Count);
+        Assert.Equal(2, export.Properties.Length);
         var property = export.Properties.First();
         Assert.Equal("name", property.Name);
         Assert.Contains("text", property.DataType);
@@ -443,7 +443,7 @@ public partial class CollectionsTests : IntegrationTests
 
         // Properties validation
         Assert.NotNull(export.Properties);
-        Assert.Equal(2, export.Properties.Count);
+        Assert.Equal(2, export.Properties.Length);
         var property = export.Properties.First();
         Assert.Equal("name", property.Name);
         Assert.Contains("text", property.DataType);

--- a/src/Weaviate.Client.Tests/Integration/TestProperties.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestProperties.cs
@@ -202,7 +202,7 @@ public partial class PropertyTests : IntegrationTests
         var export = await _weaviate.Collections.Export(c.Name);
 
         Assert.NotNull(export);
-        Assert.Equal(3, export.Properties.Count);
+        Assert.Equal(3, export.Properties.Length);
 
         // var propA = export.Properties.First(p => p.Name == "Name");
         var propA = export.Properties[0];

--- a/src/Weaviate.Client.Tests/Integration/_Integration.cs
+++ b/src/Weaviate.Client.Tests/Integration/_Integration.cs
@@ -123,7 +123,7 @@ public abstract partial class IntegrationTests : IAsyncDisposable
         {
             Name = name,
             Description = description,
-            Properties = properties?.Concat(references!.Select(p => (Property)p)).ToList() ?? [],
+            Properties = properties?.Concat(references!.Select(p => (Property)p)).ToArray() ?? [],
             VectorConfig = vectorConfig,
             MultiTenancyConfig = multiTenancyConfig,
             InvertedIndexConfig = invertedIndexConfig,

--- a/src/Weaviate.Client/Extensions.cs
+++ b/src/Weaviate.Client/Extensions.cs
@@ -247,7 +247,7 @@ public static class WeaviateExtensions
                                 Description = p.Description,
                             }
                     )
-                    .ToList() ?? [],
+                    .ToArray() ?? [],
             Properties =
                 collection
                     ?.Properties?.Where(p => p.DataType?.All(t => char.IsLower(t.First())) ?? false)
@@ -264,7 +264,7 @@ public static class WeaviateExtensions
                         IndexSearchable = p.IndexSearchable,
                         PropertyTokenization = (PropertyTokenization?)p.Tokenization,
                     })
-                    .ToList() ?? [],
+                    .ToArray() ?? [],
             InvertedIndexConfig = invertedIndexConfig,
             ModuleConfig = moduleConfig,
             RerankerConfig = reranker,

--- a/src/Weaviate.Client/Models/Collection.cs
+++ b/src/Weaviate.Client/Models/Collection.cs
@@ -6,8 +6,8 @@ public partial record Collection : IEquatable<Collection>
     public string Description { get; set; } = "";
 
     // Define properties of the collection.
-    public List<Property> Properties { get; set; } = [];
-    public List<Reference> References { get; set; } = [];
+    public Property[] Properties { get; set; } = [];
+    public Reference[] References { get; set; } = [];
 
     // inverted index config
     public InvertedIndexConfig? InvertedIndexConfig { get; set; }


### PR DESCRIPTION
Convert the Properties and References collections from List to Array across the codebase. Update related tests to reflect this change.