### PR TITLE
Fixes for AggregateClient and WeaviateGrpcClient

### DIFF
--- a/src/Weaviate.Client/AggregateClient.cs
+++ b/src/Weaviate.Client/AggregateClient.cs
@@ -38,7 +38,7 @@ public partial class AggregateClient
     }
 
     public async Task<AggregateGroupByResult> OverAll(
-        Aggregate.GroupBy? groupBy,
+        Aggregate.GroupBy groupBy,
         bool totalCount = true,
         Filter? filters = null,
         string? tenant = null,

--- a/src/Weaviate.Client/gRPC/Aggregate.cs
+++ b/src/Weaviate.Client/gRPC/Aggregate.cs
@@ -28,7 +28,7 @@ internal partial class WeaviateGrpcClient
             r.GroupBy = new AggregateRequest.Types.GroupBy
             {
                 Collection = "",
-                Property = groupBy.Property,
+                Property = groupBy.Property.Decapitalize(),
             };
 
             if (groupBy.Limit.HasValue)
@@ -280,11 +280,6 @@ internal partial class WeaviateGrpcClient
         if (queryProperties is not null && queryProperties.Length > 0)
         {
             request.Hybrid.Properties.AddRange(queryProperties);
-        }
-
-        if (groupBy is not null)
-        {
-            request.GroupBy = new AggregateRequest.Types.GroupBy { Property = groupBy.Property };
         }
 
         var (targets, _, vector) = BuildTargetVector(

--- a/src/Weaviate.Client/gRPC/Search.Builders.cs
+++ b/src/Weaviate.Client/gRPC/Search.Builders.cs
@@ -54,7 +54,7 @@ internal partial class WeaviateGrpcClient
             GroupBy = groupBy is not null
                 ? new V1.GroupBy()
                 {
-                    Path = { groupBy.PropertyName.ToLowerInvariant() },
+                    Path = { groupBy.PropertyName.Decapitalize() },
                     NumberOfGroups = Convert.ToInt32(groupBy.NumberOfGroups),
                     ObjectsPerGroup = Convert.ToInt32(groupBy.ObjectsPerGroup),
                 }


### PR DESCRIPTION
Enhance the handling of groupBy parameters and improve the overall structure of aggregate responses in the Weaviate client. Adjustments include ensuring proper capitalization and null checks for groupBy properties.