### PR TITLE
Add implicit conversion for Aggregate.GroupBy

### DIFF
--- a/src/Weaviate.Client.Tests/Integration/TestCollectionAggregate.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestCollectionAggregate.cs
@@ -510,7 +510,7 @@ public partial class AggregatesTests : IntegrationTests
 
         // Group by "text"
         var resultByText = await collectionClient.Aggregate.OverAll(
-            groupBy: new Aggregate.GroupBy("text"),
+            groupBy: "text", // shorthand for new Aggregate.GroupBy("text")
             metrics: new[]
             {
                 Metrics.ForProperty("text").Text(count: true),
@@ -529,7 +529,7 @@ public partial class AggregatesTests : IntegrationTests
 
         // Group by "int"
         var resultByInt = await collectionClient.Aggregate.OverAll(
-            groupBy: new Aggregate.GroupBy("int"),
+            groupBy: "int", // shorthand for new Aggregate.GroupBy("int")
             metrics: new[]
             {
                 Metrics.ForProperty("text").Text(count: true),

--- a/src/Weaviate.Client/Models/Aggregate.cs
+++ b/src/Weaviate.Client/Models/Aggregate.cs
@@ -391,7 +391,10 @@ public static partial class Aggregate
 
 public static partial class Aggregate
 {
-    public record GroupBy(string Property, uint? Limit = null);
+    public record GroupBy(string Property, uint? Limit = null)
+    {
+        public static implicit operator GroupBy(string property) => new(property);
+    };
 
     public abstract record Property
     {


### PR DESCRIPTION
Introduce an implicit conversion for `Aggregate.GroupBy` to simplify its usage in aggregate queries. This change allows developers to use a string directly instead of needing to instantiate a `GroupBy` object explicitly.