### PR TITLE
Refactor NearText method signatures to use OneOrManyOf<string>

### DIFF
--- a/src/Weaviate.Client.Tests/Integration/TestCollectionAggregate.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestCollectionAggregate.cs
@@ -443,7 +443,7 @@ public partial class AggregatesTests : IntegrationTests
         if (option.ContainsKey("object_limit"))
         {
             res = await collectionClient.Aggregate.NearText(
-                new[] { text1 },
+                text1,
                 metrics: metrics,
                 limit: Convert.ToUInt32(option["object_limit"])
             );
@@ -451,7 +451,7 @@ public partial class AggregatesTests : IntegrationTests
         else if (option.ContainsKey("certainty"))
         {
             res = await collectionClient.Aggregate.NearText(
-                new[] { text1 },
+                [text1],
                 metrics: metrics,
                 certainty: Convert.ToDouble(option["certainty"])
             );
@@ -459,7 +459,7 @@ public partial class AggregatesTests : IntegrationTests
         else if (option.ContainsKey("distance"))
         {
             res = await collectionClient.Aggregate.NearText(
-                new[] { text1 },
+                new[] { text1 }!,
                 metrics: metrics,
                 distance: Convert.ToDouble(option["distance"])
             );
@@ -470,7 +470,7 @@ public partial class AggregatesTests : IntegrationTests
             var moveTo = option.ContainsKey("move_to") ? option["move_to"] as Move : null;
             var moveAway = option.ContainsKey("move_away") ? option["move_away"] as Move : null;
             res = await collectionClient.Aggregate.NearText(
-                new[] { text1 },
+                new[] { text1 }!,
                 metrics: metrics,
                 moveTo: moveTo,
                 moveAway: moveAway

--- a/src/Weaviate.Client/AggregateClient.cs
+++ b/src/Weaviate.Client/AggregateClient.cs
@@ -117,7 +117,7 @@ public partial class AggregateClient
     }
 
     public async Task<AggregateGroupByResult> NearText(
-        string[] query,
+        OneOrManyOf<string> query,
         Aggregate.GroupBy? groupBy,
         double? certainty = null,
         double? distance = null,
@@ -133,7 +133,7 @@ public partial class AggregateClient
     {
         var result = await _client.GrpcClient.AggregateNearText(
             _collectionName,
-            query,
+            query.ToArray(),
             certainty,
             distance,
             limit,
@@ -151,7 +151,7 @@ public partial class AggregateClient
     }
 
     public async Task<AggregateResult> NearText(
-        string[] query,
+        OneOrManyOf<string> query,
         double? certainty = null,
         double? distance = null,
         uint? limit = null,
@@ -166,7 +166,7 @@ public partial class AggregateClient
     {
         var result = await _client.GrpcClient.AggregateNearText(
             _collectionName,
-            query,
+            query.ToArray(),
             certainty,
             distance,
             limit,

--- a/src/Weaviate.Client/GenerateClient.cs
+++ b/src/Weaviate.Client/GenerateClient.cs
@@ -163,7 +163,7 @@ public class GenerateClient
     {
         var result = await _client.GrpcClient.SearchNearText(
             _collectionClient.Name,
-            text,
+            text.ToArray(),
             distance: distance,
             certainty: certainty,
             limit: limit,
@@ -208,7 +208,7 @@ public class GenerateClient
     {
         var result = await _client.GrpcClient.SearchNearText(
             _collectionClient.Name,
-            text,
+            text.ToArray(),
             groupBy: groupBy,
             distance: distance,
             certainty: certainty,

--- a/src/Weaviate.Client/QueryClient.cs
+++ b/src/Weaviate.Client/QueryClient.cs
@@ -125,7 +125,7 @@ public class QueryClient<TData>
     ) =>
         await _grpc.SearchNearText(
             _collectionClient.Name,
-            text,
+            text.ToArray(),
             distance: distance,
             certainty: certainty,
             limit: limit,
@@ -163,7 +163,7 @@ public class QueryClient<TData>
     ) =>
         await _grpc.SearchNearText(
             _collectionClient.Name,
-            text,
+            text.ToArray(),
             groupBy: groupBy,
             distance: distance,
             certainty: certainty,

--- a/src/Weaviate.Client/gRPC/Search.Builders.cs
+++ b/src/Weaviate.Client/gRPC/Search.Builders.cs
@@ -450,7 +450,7 @@ internal partial class WeaviateGrpcClient
     }
 
     private static NearTextSearch BuildNearText(
-        OneOrManyOf<string> query,
+        string[] query,
         double? distance,
         double? certainty,
         Move? moveTo,
@@ -599,7 +599,7 @@ internal partial class WeaviateGrpcClient
         if (vector is null && nearText is not null && nearVector is null)
         {
             request.HybridSearch.NearText = BuildNearText(
-                nearText.Query,
+                [nearText.Query],
                 nearText.Distance,
                 nearText.Certainty,
                 nearText.MoveTo,

--- a/src/Weaviate.Client/gRPC/Search.cs
+++ b/src/Weaviate.Client/gRPC/Search.cs
@@ -104,7 +104,7 @@ internal partial class WeaviateGrpcClient
 
     internal async Task<SearchReply> SearchNearText(
         string collection,
-        OneOrManyOf<string> query,
+        string[] query,
         float? distance = null,
         float? certainty = null,
         uint? limit = null,


### PR DESCRIPTION
Update NearText method signatures and related logic for consistency across the client and tests. This change enhances flexibility in handling single or multiple query strings.

Closes #137