### PR TITLE
Refactor InsertMany API to use IEnumerable<T>

### DIFF
--- a/src/Weaviate.Client.Tests/Integration/TestBatch.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestBatch.cs
@@ -60,7 +60,7 @@ public partial class BatchTests : IntegrationTests
 
         // Insert objects into the referenced collection and get their UUIDs
         var refInsertResult = await refCollection.Data.InsertMany(
-            Enumerable.Range(0, numObjects).Select(i => new { Number = i })
+            [.. Enumerable.Range(0, numObjects).Select(i => new { Number = i })]
         );
 
         Guid[] uuidsTo = [.. refInsertResult.Select(r => r.ID!.Value)];
@@ -75,7 +75,7 @@ public partial class BatchTests : IntegrationTests
 
         // Insert objects into the main collection and get their UUIDs
         var fromInsertResult = await collection.Data.InsertMany(
-            Enumerable.Range(0, numObjects).Select(i => new { Num = i })
+            [.. Enumerable.Range(0, numObjects).Select(i => new { Num = i })]
         );
 
         Guid[] uuidsFrom = [.. fromInsertResult.Select(r => r.ID!.Value)];

--- a/src/Weaviate.Client.Tests/Integration/TestBatchDelete.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestBatchDelete.cs
@@ -13,7 +13,7 @@ public partial class BatchDeleteTests : IntegrationTests
             vectorConfig: new VectorConfig("default", new Vectorizer.SelfProvided())
         );
 
-        await collection.Data.InsertMany((new { name = "delet me" }, Guid.NewGuid()));
+        await collection.Data.InsertMany([new { name = "delet me" }]);
 
         var result = await collection.Data.DeleteMany(
             where: Filter.Property("name").Equal("delet me")
@@ -34,9 +34,11 @@ public partial class BatchDeleteTests : IntegrationTests
         );
 
         await collection.Data.InsertMany(
-            (new { age = 10, name = "Timmy" }, Guid.NewGuid()),
-            (new { age = 20, name = "Tim" }, Guid.NewGuid()),
-            (new { age = 30, name = "Timothy" }, Guid.NewGuid())
+            [
+                new { age = 10, name = "Timmy" },
+                new { age = 20, name = "Tim" },
+                new { age = 30, name = "Timothy" },
+            ]
         );
 
         var objects = await collection.Query.FetchObjects();
@@ -61,8 +63,7 @@ public partial class BatchDeleteTests : IntegrationTests
         );
 
         await collection.Data.InsertMany(
-            (new { age = 10, name = "Timmy" }, Guid.NewGuid()),
-            (new { age = 10, name = "Tommy" }, Guid.NewGuid())
+            [new { age = 10, name = "Timmy" }, new { age = 10, name = "Tommy" }]
         );
 
         var objects = await collection.Query.FetchObjects();

--- a/src/Weaviate.Client.Tests/Integration/TestCollectionAggregate.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestCollectionAggregate.cs
@@ -18,7 +18,7 @@ public partial class AggregatesTests : IntegrationTests
         );
 
         await collectionClient.Data.InsertMany(
-            Enumerable.Repeat(BatchInsertRequest.Create<object>(new { }), howMany)
+            [.. Enumerable.Repeat(BatchInsertRequest.Create<object>(new { }), howMany)]
         );
 
         var count = await collectionClient.Count();
@@ -555,7 +555,7 @@ public partial class AggregatesTests : IntegrationTests
             _ => throw new ArgumentException("Unknown property type"),
         };
 
-        await collectionClient.Data.InsertMany(BatchInsertRequest.Create(insertObj));
+        await collectionClient.Data.InsertMany([BatchInsertRequest.Create(insertObj)]);
 
         Aggregate.Metric metric = propertyType switch
         {

--- a/src/Weaviate.Client.Tests/Integration/TestCollections.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestCollections.cs
@@ -1165,7 +1165,7 @@ public partial class CollectionsTests : IntegrationTests
 
         // Insert many
         await collection.Data.InsertMany(
-            BatchInsertRequest.Create<object>(new { blob = blobData })
+            [BatchInsertRequest.Create<object>(new { blob = blobData })]
         );
 
         // Fetch by id

--- a/src/Weaviate.Client.Tests/Integration/TestIterator.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestIterator.cs
@@ -12,9 +12,7 @@ public partial class BasicTests
             vectorConfig: new VectorConfig("default", new Vectorizer.SelfProvided())
         );
 
-        await collection.Data.InsertMany(
-            BatchInsertRequest.Create<object>(new { Name = "Name 1" }, new { Name = "Name 2" })
-        );
+        await collection.Data.InsertMany([new { Name = "Name 1" }, new { Name = "Name 2" }]);
 
         var names = new List<string>();
         await foreach (
@@ -69,7 +67,7 @@ public partial class BasicTests
         var insertData = Enumerable
             .Range(0, 10)
             .Select(i => BatchInsertRequest.Create<object>(new { data = i, text = "hi" }));
-        await collection.Data.InsertMany(insertData);
+        await collection.Data.InsertMany([.. insertData]);
 
         // Build metadata query
         MetadataQuery? metadata = null;
@@ -171,7 +169,7 @@ public partial class BasicTests
             .Range(0, 10)
             .Select(_ => BatchInsertRequest.Create<object>(new { @this = "this", that = "that" }))
             .ToArray();
-        await collection.Data.InsertMany(insertData);
+        await collection.Data.InsertMany([.. insertData]);
 
         // Test with all properties
         var allPropsIter = collection.Iterator(
@@ -221,7 +219,7 @@ public partial class BasicTests
                 .Range(0, (int)count)
                 .Select(i => BatchInsertRequest.Create<object>(new { data = i }))
                 .ToArray();
-            await collection.Data.InsertMany(insertData);
+            await collection.Data.InsertMany([.. insertData]);
         }
 
         var expected = Enumerable.Range(0, (int)count).Select(x => Convert.ToInt64(x)).ToList();
@@ -265,7 +263,7 @@ public partial class BasicTests
             .Range(0, 10)
             .Select(i => BatchInsertRequest.Create<object>(new { data = i }))
             .ToArray();
-        await collection.Data.InsertMany(insertData);
+        await collection.Data.InsertMany([.. insertData]);
 
         // Get all UUIDs first
         var allUuids = new List<Guid>();

--- a/src/Weaviate.Client.Tests/Integration/TestMultiVector.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestMultiVector.cs
@@ -130,22 +130,24 @@ public class TestMultiVector : IntegrationTests
         );
 
         var result = await collection.Data.InsertMany(
-            BatchInsertRequest.Create<object>(
-                new { },
-                null,
-                new Vectors()
-                {
-                    { "regular", new[] { 1f, 2f } },
+            [
+                BatchInsertRequest.Create<object>(
+                    new { },
+                    null,
+                    new Vectors()
                     {
-                        "colbert",
-                        new[,]
+                        { "regular", new[] { 1f, 2f } },
                         {
-                            { 1f, 2f },
-                            { 4f, 5f },
-                        }
-                    },
-                }
-            )
+                            "colbert",
+                            new[,]
+                            {
+                                { 1f, 2f },
+                                { 4f, 5f },
+                            }
+                        },
+                    }
+                ),
+            ]
         );
 
         Assert.Equal(0, result.Count(r => r.Error != null));

--- a/src/Weaviate.Client.Tests/Integration/TestNamedVectorMultiTarget.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestNamedVectorMultiTarget.cs
@@ -393,22 +393,24 @@ public class TestNamedVectorMultiTarget : IntegrationTests
 
         var inserts = (
             await collection.Data.InsertMany(
-                new BatchInsertRequest<object>(
-                    Data: new { },
-                    Vectors: new Vectors
-                    {
-                        { "first", new[] { 1f, 0f } },
-                        { "second", new[] { 0f, 1f, 0f } },
-                    }
-                ),
-                new BatchInsertRequest<object>(
-                    Data: new { },
-                    Vectors: new Vectors
-                    {
-                        { "first", new[] { 0f, 1f } },
-                        { "second", new[] { 1f, 0f, 0f } },
-                    }
-                )
+                [
+                    new BatchInsertRequest<object>(
+                        Data: new { },
+                        Vectors: new Vectors
+                        {
+                            { "first", new[] { 1f, 0f } },
+                            { "second", new[] { 0f, 1f, 0f } },
+                        }
+                    ),
+                    new BatchInsertRequest<object>(
+                        Data: new { },
+                        Vectors: new Vectors
+                        {
+                            { "first", new[] { 0f, 1f } },
+                            { "second", new[] { 1f, 0f, 0f } },
+                        }
+                    ),
+                ]
             )
         ).ToList();
 

--- a/src/Weaviate.Client.Tests/Integration/TestProperties.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestProperties.cs
@@ -181,7 +181,7 @@ public partial class PropertyTests : IntegrationTests
         );
 
         var id = await c.Data.Insert(obj);
-        var idb = (await cb.Data.InsertMany(BatchInsertRequest.Create(new[] { obj })))
+        var idb = (await cb.Data.InsertMany([BatchInsertRequest.Create(new[] { obj })]))
             .First()
             .ID!.Value;
 
@@ -372,9 +372,7 @@ public partial class PropertyTests : IntegrationTests
             properties: props
         );
 
-        var requests = BatchInsertRequest.Create(testData);
-
-        var response = await c.Data.InsertMany(requests);
+        var response = await c.Data.InsertMany(testData);
 
         // 3. Retrieve the object and confirm all properties match
         foreach (var r in response)
@@ -531,7 +529,7 @@ public partial class PropertyTests : IntegrationTests
 
         var requests = BatchInsertRequest.Create<object>(testData);
 
-        var response = await c.Data.InsertMany(requests);
+        var response = await c.Data.InsertMany([.. requests]);
 
         // 3. Retrieve the object and confirm all properties match
         foreach (var r in response)
@@ -772,7 +770,7 @@ public partial class PropertyTests : IntegrationTests
             new { amount = 999.99, values = new[] { 7.77, 8.88, 9.99 } },
         };
 
-        var response = await c.Data.InsertMany(BatchInsertRequest.Create<object>(testData));
+        var response = await c.Data.InsertMany([BatchInsertRequest.Create<object>(testData)]);
 
         // Verify each inserted object
         foreach (var r in response)

--- a/src/Weaviate.Client.Tests/Integration/TestQueries.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestQueries.cs
@@ -46,7 +46,7 @@ public class TestQueries : IntegrationTests
             },
         };
 
-        await collection.Data.InsertMany(BatchInsertRequest.Create(testData));
+        await collection.Data.InsertMany(testData);
 
         // Act
         var dataDesc = await collection.Query.FetchObjects(
@@ -92,7 +92,7 @@ public class TestQueries : IntegrationTests
             },
         };
 
-        await collection.Data.InsertMany(BatchInsertRequest.Create<object>(testData));
+        await collection.Data.InsertMany([BatchInsertRequest.Create<object>(testData)]);
 
         // Act
         var groupBy = new GroupByRequest
@@ -154,9 +154,11 @@ public class TestQueries : IntegrationTests
 
         // Insert data
         await collection.Data.InsertMany(
-            BatchInsertRequest.Create<object>(
-                new[] { new { text = "John Doe" }, new { text = "Jane Doe" } }
-            )
+            [
+                BatchInsertRequest.Create<object>(
+                    new[] { new { text = "John Doe" }, new { text = "Jane Doe" } }
+                ),
+            ]
         );
 
         // Act: generative fetch
@@ -237,9 +239,11 @@ public class TestQueries : IntegrationTests
         );
 
         var result = await collection.Data.InsertMany(
-            (new { text = "John Doe" }, id: _reusableUuids[0]),
-            (new { text = "Jane Doe" }, id: _reusableUuids[1]),
-            (new { text = "J. Doe" }, id: _reusableUuids[2])
+            [
+                BatchInsertRequest.Create(new { text = "John Doe" }, _reusableUuids[0]),
+                BatchInsertRequest.Create(new { text = "Jane Doe" }, _reusableUuids[1]),
+                BatchInsertRequest.Create(new { text = "J. Doe" }, _reusableUuids[2]),
+            ]
         );
 
         var res = await collection.Generate.FetchObjectsByIDs(

--- a/src/Weaviate.Client.Tests/Integration/TestSearchHybrid.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestSearchHybrid.cs
@@ -114,11 +114,7 @@ public partial class SearchTests : IntegrationTests
         );
 
         var res = await collection.Data.InsertMany(
-            BatchInsertRequest.Create<object>(
-                new { Name = "test" },
-                new { Name = "another" },
-                new { Name = "test" }
-            )
+            [new { Name = "test" }, new { Name = "another" }, new { Name = "test" }]
         );
 
         Assert.Equal(0, res.Count(r => r.Error is not null));
@@ -140,11 +136,7 @@ public partial class SearchTests : IntegrationTests
         );
 
         var res = await collection.Data.InsertMany(
-            BatchInsertRequest.Create<object>(
-                new { Name = "test" },
-                new { Name = "another" },
-                new { Name = "test" }
-            )
+            [new { Name = "test" }, new { Name = "another" }, new { Name = "test" }]
         );
 
         Assert.Equal(0, res.Count(r => r.Error is not null));
@@ -163,11 +155,7 @@ public partial class SearchTests : IntegrationTests
         );
 
         var res = await collection.Data.InsertMany(
-            BatchInsertRequest.Create<object>(
-                new { name = "banana" },
-                new { name = "fruit" },
-                new { name = "car" }
-            )
+            [new { name = "banana" }, new { name = "fruit" }, new { name = "car" }]
         );
         Assert.Equal(0, res.Count(r => r.Error is not null));
 

--- a/src/Weaviate.Client.Tests/Integration/TestTenant.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestTenant.cs
@@ -35,7 +35,7 @@ public partial class TenantTests : IntegrationTests
         var tenant2Collection = collectionClient.WithTenant("tenant2");
         var items = Enumerable.Range(0, (int)(howMany * 2)).Select(x => new { }).ToArray();
         var result = await tenant2Collection.Data.InsertMany(
-            BatchInsertRequest.Create<object>(items)
+            [BatchInsertRequest.Create<object>(items)]
         );
 
         Assert.Equal(0, result.Count(r => r.Error != null));
@@ -103,15 +103,17 @@ public partial class TenantTests : IntegrationTests
 
         var result = (
             await tenant1Collection.Data.InsertMany(
-                BatchInsertRequest.Create<object>(
-                    new { Name = "some name" },
-                    null,
-                    new float[] { 1, 2, 3 }
-                ),
-                BatchInsertRequest.Create<object>(
-                    new { Name = "some other name" },
-                    _reusableUuids[0]
-                )
+                [
+                    BatchInsertRequest.Create<object>(
+                        new { Name = "some name" },
+                        null,
+                        new float[] { 1, 2, 3 }
+                    ),
+                    BatchInsertRequest.Create<object>(
+                        new { Name = "some other name" },
+                        _reusableUuids[0]
+                    ),
+                ]
             )
         ).ToList();
 
@@ -726,14 +728,16 @@ public partial class TenantTests : IntegrationTests
 
         // Batch insert 101 objects for tenants "tenant-0" to "tenant-100"
         var batchResult = await collectionClient.Data.InsertMany(
-            Enumerable
-                .Range(0, 101)
-                .Select(i =>
-                    BatchInsertRequest.Create<object>(
-                        new { name = "some name" },
-                        tenant: $"tenant-{i}"
-                    )
-                )
+            [
+                .. Enumerable
+                    .Range(0, 101)
+                    .Select(i =>
+                        BatchInsertRequest.Create<object>(
+                            new { name = "some name" },
+                            tenant: $"tenant-{i}"
+                        )
+                    ),
+            ]
         );
 
         Assert.Equal(0, batchResult.Count(r => r.Error != null));

--- a/src/Weaviate.Client/DataClient.cs
+++ b/src/Weaviate.Client/DataClient.cs
@@ -89,41 +89,21 @@ public class DataClient<TData>
         var response = await _client.RestClient.ObjectReplace(_collectionName, dto);
     }
 
-    public async Task<BatchInsertResponse> InsertMany(params TData[] data)
-    {
-        return await InsertMany(data.AsEnumerable());
-    }
-
     public async Task<BatchInsertResponse> InsertMany(IEnumerable<TData> data)
     {
         return await InsertMany(data.Select(r => BatchInsertRequest.Create<TData>(r)));
     }
 
     public async Task<BatchInsertResponse> InsertMany(IEnumerable<(TData, Guid id)> requests) =>
-        await InsertMany(requests.Select(r => BatchInsertRequest.Create<TData>(r)));
+        await InsertMany(BatchInsertRequest.Create<TData>(requests));
 
     public async Task<BatchInsertResponse> InsertMany(
         IEnumerable<(TData, Models.Vectors vectors)> requests
-    ) => await InsertMany(requests.Select(r => BatchInsertRequest.Create<TData>(r)));
+    ) => await InsertMany(BatchInsertRequest.Create<TData>(requests));
 
     public async Task<BatchInsertResponse> InsertMany(
         IEnumerable<(TData data, IEnumerable<ObjectReference>? references)> requests
-    ) => await InsertMany(requests.Select(r => BatchInsertRequest.Create<TData>(r)));
-
-    public async Task<BatchInsertResponse> InsertMany(params (TData, Guid id)[] requests) =>
-        await InsertMany(requests.AsEnumerable());
-
-    public async Task<BatchInsertResponse> InsertMany(
-        params (TData, Models.Vectors vectors)[] requests
-    ) => await InsertMany(requests.AsEnumerable());
-
-    public async Task<BatchInsertResponse> InsertMany(
-        params (TData data, IEnumerable<ObjectReference>? references)[] requests
-    ) => await InsertMany(requests.AsEnumerable());
-
-    public async Task<BatchInsertResponse> InsertMany(
-        params BatchInsertRequest<TData>[] requests
-    ) => await InsertMany(requests.AsEnumerable());
+    ) => await InsertMany(BatchInsertRequest.Create<TData>(requests));
 
     public async Task<BatchInsertResponse> InsertMany(
         IEnumerable<BatchInsertRequest<TData>[]> requestBatches

--- a/src/Weaviate.Client/Models/Batch.cs
+++ b/src/Weaviate.Client/Models/Batch.cs
@@ -24,32 +24,33 @@ public static class BatchInsertRequest
         return new BatchInsertRequest<TData>(data, id, vectors, references, tenant);
     }
 
-    public static BatchInsertRequest<TData>[] Create<TData>(params TData[] data)
+    public static IEnumerable<BatchInsertRequest<TData>> Create<TData>(IEnumerable<TData> data)
     {
-        return data.Select(d => new BatchInsertRequest<TData>(d)).ToArray();
+        return data.Select(d => new BatchInsertRequest<TData>(d));
     }
 
-    public static BatchInsertRequest<TData>[] Create<TData>(params (TData data, Guid id)[] requests)
-    {
-        return requests.Select(r => new BatchInsertRequest<TData>(r.data, r.id)).ToArray();
-    }
-
-    public static BatchInsertRequest<TData>[] Create<TData>(
-        params (TData data, IEnumerable<ObjectReference>? references)[] requests
+    public static IEnumerable<BatchInsertRequest<TData>> Create<TData>(
+        IEnumerable<(TData data, Guid id)> requests
     )
     {
-        return requests
-            .Select(r => new BatchInsertRequest<TData>(r.data, References: r.references))
-            .ToArray();
+        return requests.Select(r => new BatchInsertRequest<TData>(r.data, r.id));
     }
 
-    public static BatchInsertRequest<TData>[] Create<TData>(
-        params (TData data, Vectors vectors)[] requests
+    public static IEnumerable<BatchInsertRequest<TData>> Create<TData>(
+        IEnumerable<(TData data, IEnumerable<ObjectReference>? references)> requests
     )
     {
-        return requests
-            .Select(r => new BatchInsertRequest<TData>(r.data, Vectors: r.vectors))
-            .ToArray();
+        return requests.Select(r => new BatchInsertRequest<TData>(
+            r.data,
+            References: r.references
+        ));
+    }
+
+    public static IEnumerable<BatchInsertRequest<TData>> Create<TData>(
+        IEnumerable<(TData data, Vectors vectors)> requests
+    )
+    {
+        return requests.Select(r => new BatchInsertRequest<TData>(r.data, Vectors: r.vectors));
     }
 }
 

--- a/src/Weaviate.Client/ObjectHelper.cs
+++ b/src/Weaviate.Client/ObjectHelper.cs
@@ -431,11 +431,31 @@ internal class ObjectHelper
 
     internal static V1.BatchObject.Types.Properties BuildBatchProperties<TProps>(TProps data)
     {
+        return BuildBatchProperties(data, []);
+    }
+
+    internal static V1.BatchObject.Types.Properties BuildBatchProperties<TProps>(
+        TProps data,
+        HashSet<int> visitedObjects
+    )
+    {
         var props = new V1.BatchObject.Types.Properties();
 
         if (data is null)
         {
             return props;
+        }
+
+        // Check for circular references
+        if (!data.GetType().IsValueType)
+        {
+            var objectHash = System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(data);
+            if (visitedObjects.Contains(objectHash))
+            {
+                // Circular reference detected, return empty properties
+                return props;
+            }
+            visitedObjects.Add(objectHash);
         }
 
         Google.Protobuf.WellKnownTypes.Struct? nonRefProps = null;
@@ -511,7 +531,10 @@ internal class ObjectHelper
                                 else
                                 {
                                     structValue.Fields[nestedPropName] = ConvertToProtoValue(
-                                        BuildBatchProperties(nestedVal).NonRefProperties
+                                        BuildBatchProperties(
+                                            nestedVal,
+                                            visitedObjects
+                                        ).NonRefProperties
                                     );
                                 }
                             }
@@ -708,7 +731,7 @@ internal class ObjectHelper
             if (!propType.IsNativeType())
             {
                 nonRefProps ??= new();
-                var nestedStruct = BuildBatchProperties(value).NonRefProperties;
+                var nestedStruct = BuildBatchProperties(value, visitedObjects).NonRefProperties;
                 if (nestedStruct != null)
                 {
                     nonRefProps.Fields.Add(


### PR DESCRIPTION
Replace params overloads in the InsertMany API with IEnumerable<T> to resolve a stack overflow issue caused by incorrect CancellationToken capture. This change enhances API clarity, supports deferred execution, and prevents method signature ambiguity. Update all related tests to reflect the new API usage.