### PR TITLE
Fix GitHub Actions workflow permissions issue

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,6 +1,7 @@
 name: Integration Test Template
 permissions:
   contents: read
+  checks: write
 
 on:
   workflow_call:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -288,3 +288,4 @@ jobs:
           generate_release_notes: true
           draft: true
           files: ./out/*.nupkg
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-on-weaviate-version.yml
+++ b/.github/workflows/test-on-weaviate-version.yml
@@ -1,6 +1,7 @@
 name: Test on Weaviate Version
 permissions:
   contents: read
+  checks: write
 
 on:
   workflow_call:


### PR DESCRIPTION
- Add `checks: write` permission to integration-test.yml to allow dorny/test-reporter to post test results to PRs
- Add `checks: write` permission to test-on-weaviate-version.yml to properly inherit permissions for called workflows
- Explicitly pass GITHUB_TOKEN to softprops/action-gh-release for better security and clarity