### PR TITLE
Redesign Property Creation and Structure

### DIFF
--- a/docs/PROPERTY_SYSTEM.md
+++ b/docs/PROPERTY_SYSTEM.md
@@ -1,0 +1,1254 @@
+# Property System Documentation
+
+## Overview
+
+The Property system in the Weaviate C# client provides a type-safe way to define and manage collection properties and references. This document explains the architecture, usage patterns, and implementation details.
+
+## Table of Contents
+
+- [Core Concepts](#core-concepts)
+- [DataType Enum](#datatype-enum)
+- [Property Model](#property-model)
+- [Reference Model](#reference-model)
+- [Usage Patterns](#usage-patterns)
+- [Serialization](#serialization)
+- [Type Inference](#type-inference)
+- [Validation](#validation)
+- [Advanced Topics](#advanced-topics)
+
+## Core Concepts
+
+### Property vs Reference
+
+The Property system distinguishes between two fundamental concepts:
+
+- **Property**: A data field with a specific data type (e.g., text, int, boolean)
+- **Reference**: A relationship to one or more target collections
+
+```csharp
+// Property - has a single DataType enum value
+var titleProperty = new Property
+{
+    Name = "title",
+    DataType = DataType.Text,
+    IndexSearchable = true
+};
+
+// Reference - has a list of target collection names
+var authorReference = new Reference(
+    name: "author",
+    targetCollection: "Author",
+    description: "The article's author"
+);
+```
+
+### Key Architectural Decisions
+
+1. **Property uses enum**: Type-safe `DataType` enum for compile-time checking
+2. **Reference uses strings**: Dynamic `IList<string>` for target collection names
+3. **Separate serialization paths**: Properties and References serialize differently
+4. **Name transformation**: Property/Reference names are automatically decapitalized
+
+## DataType Enum
+
+### Definition
+
+The `DataType` enum defines all supported Weaviate data types with `[EnumMember]` attributes for wire format compatibility:
+
+```csharp
+public enum DataType
+{
+    [System.Runtime.Serialization.EnumMember(Value = "unknown")]
+    Unknown,
+
+    // Text types
+    [System.Runtime.Serialization.EnumMember(Value = "text")]
+    Text,
+    [System.Runtime.Serialization.EnumMember(Value = "text[]")]
+    TextArray,
+
+    // Numeric types
+    [System.Runtime.Serialization.EnumMember(Value = "int")]
+    Int,
+    [System.Runtime.Serialization.EnumMember(Value = "int[]")]
+    IntArray,
+    [System.Runtime.Serialization.EnumMember(Value = "number")]
+    Number,
+    [System.Runtime.Serialization.EnumMember(Value = "number[]")]
+    NumberArray,
+
+    // Boolean types
+    [System.Runtime.Serialization.EnumMember(Value = "boolean")]
+    Bool,
+    [System.Runtime.Serialization.EnumMember(Value = "boolean[]")]
+    BoolArray,
+
+    // Date types
+    [System.Runtime.Serialization.EnumMember(Value = "date")]
+    Date,
+    [System.Runtime.Serialization.EnumMember(Value = "date[]")]
+    DateArray,
+
+    // UUID types
+    [System.Runtime.Serialization.EnumMember(Value = "uuid")]
+    Uuid,
+    [System.Runtime.Serialization.EnumMember(Value = "uuid[]")]
+    UuidArray,
+
+    // Special types
+    [System.Runtime.Serialization.EnumMember(Value = "geoCoordinates")]
+    GeoCoordinate,
+    [System.Runtime.Serialization.EnumMember(Value = "blob")]
+    Blob,
+    [System.Runtime.Serialization.EnumMember(Value = "phoneNumber")]
+    PhoneNumber,
+
+    // Object types
+    [System.Runtime.Serialization.EnumMember(Value = "object")]
+    Object,
+    [System.Runtime.Serialization.EnumMember(Value = "object[]")]
+    ObjectArray
+}
+```
+
+### Extension Methods
+
+Two extension methods handle conversion between enum and string representations:
+
+```csharp
+// Convert enum to wire format string
+DataType.Text.ToEnumMemberValue()  // Returns "text"
+DataType.IntArray.ToEnumMemberValue()  // Returns "int[]"
+
+// Convert string to enum
+"text".ToDataTypeEnum()  // Returns DataType.Text
+"boolean[]".ToDataTypeEnum()  // Returns DataType.BoolArray
+"invalid".ToDataTypeEnum()  // Returns null
+```
+
+### C# Type Mapping
+
+The `PropertyHelper` class provides automatic type mapping from C# types to DataType enum values:
+
+| C# Type | DataType |
+|---------|----------|
+| `string` | `DataType.Text` |
+| `int`, `uint`, `short`, `ushort`, `long`, `ulong` | `DataType.Int` |
+| `float`, `double`, `decimal` | `DataType.Number` |
+| `bool` | `DataType.Bool` |
+| `DateTime` | `DataType.Date` |
+| `Guid` | `DataType.Uuid` |
+| `GeoCoordinate` | `DataType.GeoCoordinate` |
+| `PhoneNumber` | `DataType.PhoneNumber` |
+| `byte[]`, `sbyte[]` | `DataType.Blob` |
+| `string[]`, `List<string>` | `DataType.TextArray` |
+| `int[]`, `List<int>` | `DataType.IntArray` |
+| `bool[]`, `List<bool>` | `DataType.BoolArray` |
+| `DateTime[]`, `List<DateTime>` | `DataType.DateArray` |
+| `Guid[]`, `List<Guid>` | `DataType.UuidArray` |
+| `float[]`, `double[]`, `decimal[]` | `DataType.NumberArray` |
+| Custom class | `DataType.Object` |
+| Custom class array/list | `DataType.ObjectArray` |
+| Enums | `DataType.Text` (serialized as string) |
+
+## Property Model
+
+### Structure
+
+```csharp
+public record Property : IEquatable<Property>
+{
+    // Required properties
+    public required string Name { get; set; }  // Auto-decapitalized
+    public required DataType DataType { get; set; }
+
+    // Optional properties
+    public string? Description { get; set; }
+    public bool? IndexFilterable { get; set; }
+    public bool? IndexRangeFilters { get; set; }
+    public bool? IndexSearchable { get; set; }
+    public PropertyTokenization? PropertyTokenization { get; set; }
+    public Property[]? NestedProperties { get; set; }  // For object types
+
+    // Constructor
+    [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+    public Property(string name, DataType dataType)
+    {
+        Name = name;  // Goes through setter for decapitalization
+        DataType = dataType;
+    }
+}
+```
+
+### Name Transformation
+
+The `Name` property automatically decapitalizes the first letter:
+
+```csharp
+var property = new Property { Name = "Title", DataType = DataType.Text };
+Console.WriteLine(property.Name);  // Output: "title"
+
+var property2 = new Property("AuthorName", DataType.Text);
+Console.WriteLine(property2.Name);  // Output: "authorName"
+```
+
+This ensures Weaviate naming conventions are followed (properties start with lowercase).
+
+### Initialization Patterns
+
+Two initialization patterns are supported:
+
+```csharp
+// Pattern 1: Constructor + object initializer
+var property1 = new Property("title", DataType.Text)
+{
+    Description = "Article title",
+    IndexSearchable = true,
+    IndexFilterable = true
+};
+
+// Pattern 2: Object initializer only
+var property2 = new Property
+{
+    Name = "title",
+    DataType = DataType.Text,
+    Description = "Article title",
+    IndexSearchable = true,
+    IndexFilterable = true
+};
+```
+
+Both patterns ensure the `Name` property goes through its setter for decapitalization.
+
+### Static Factory Methods
+
+The `Property` class provides static factory methods for all data types:
+
+```csharp
+// Simple text property
+var title = Property.Text("title");
+
+// Integer property with indexing
+var count = Property.Int("count", indexFilterable: true);
+
+// Number array property
+var scores = Property.NumberArray("scores");
+
+// Object property with nested properties
+var address = Property.Object(
+    "address",
+    subProperties:
+    [
+        Property.Text("street"),
+        Property.Text("city"),
+        Property.Text("zipCode")
+    ]
+);
+
+// All available factory methods:
+Property.Text(name, ...)
+Property.TextArray(name, ...)
+Property.Int(name, ...)
+Property.IntArray(name, ...)
+Property.Bool(name, ...)
+Property.BoolArray(name, ...)
+Property.Number(name, ...)
+Property.NumberArray(name, ...)
+Property.Date(name, ...)
+Property.DateArray(name, ...)
+Property.Uuid(name, ...)
+Property.UuidArray(name, ...)
+Property.GeoCoordinate(name, ...)
+Property.Blob(name, ...)
+Property.PhoneNumber(name, ...)
+Property.Object(name, ...)
+Property.ObjectArray(name, ...)
+```
+
+### Generic Type-Based Factory
+
+For type-safe property creation based on C# types:
+
+```csharp
+// Infers DataType.Text from string
+var title = Property<string>.New("title");
+
+// Infers DataType.Int from int
+var age = Property<int>.New("age");
+
+// Infers DataType.DateArray from DateTime[]
+var dates = Property<DateTime[]>.New("importantDates");
+
+// Infers DataType.Object from custom class
+public class Address
+{
+    public string Street { get; set; }
+    public string City { get; set; }
+}
+var address = Property<Address>.New("address");
+```
+
+### Nested Properties (Objects)
+
+For `Object` and `ObjectArray` types, you can define nested properties:
+
+```csharp
+var personProperty = Property.Object(
+    "person",
+    description: "A person object",
+    subProperties:
+    [
+        Property.Text("firstName"),
+        Property.Text("lastName"),
+        Property.Int("age"),
+        Property.Object(
+            "address",
+            subProperties:
+            [
+                Property.Text("street"),
+                Property.Text("city"),
+                Property.Text("country")
+            ]
+        )
+    ]
+);
+```
+
+### Property Equality
+
+Properties implement `IEquatable<Property>` and compare all fields:
+
+```csharp
+var prop1 = new Property("title", DataType.Text) { IndexSearchable = true };
+var prop2 = new Property("title", DataType.Text) { IndexSearchable = true };
+var prop3 = new Property("title", DataType.Text) { IndexSearchable = false };
+
+Console.WriteLine(prop1.Equals(prop2));  // true
+Console.WriteLine(prop1 == prop2);       // true (record equality)
+Console.WriteLine(prop1.Equals(prop3));  // false (different IndexSearchable)
+```
+
+Nested properties are compared recursively using `SequenceEqual`.
+
+## Reference Model
+
+### Structure
+
+```csharp
+// Public interface for polymorphic serialization
+internal interface IReferenceBase
+{
+    string Name { get; }
+    IList<string> TargetCollections { get; }
+    string? Description { get; }
+}
+
+// Reference record
+public record Reference(string Name, string TargetCollection, string? Description = null)
+    : IReferenceBase
+{
+    public string? Description { get; set; } = Description;
+
+    // Explicit interface implementation
+    IList<string> IReferenceBase.TargetCollections { get; } = [TargetCollection];
+}
+```
+
+### Usage
+
+```csharp
+// Simple reference to one collection
+var author = new Reference(
+    name: "author",
+    targetCollection: "Author",
+    description: "The article's author"
+);
+
+// Access properties
+Console.WriteLine(author.Name);             // "author"
+Console.WriteLine(author.TargetCollection); // "Author"
+
+// Via interface for serialization
+IReferenceBase refBase = author;
+Console.WriteLine(refBase.TargetCollections[0]);  // "Author"
+```
+
+### Static Factory Method
+
+```csharp
+// Alternative creation using Property.Reference
+var category = Property.Reference(
+    name: "category",
+    targetCollection: "Category",
+    description: "Article category"
+);
+```
+
+### Design Rationale
+
+References use `IList<string>` for target collections (accessed via interface) because:
+1. Collection names are dynamic (defined by users)
+2. Wire format uses string arrays
+3. No benefit to compile-time type checking of collection names
+
+The `IReferenceBase` interface provides a unified way to serialize Properties and References:
+- Properties serialize using `DataType.ToEnumMemberValue()`
+- References serialize using `TargetCollections` directly
+
+## Usage Patterns
+
+### Manual Property Definition
+
+```csharp
+using Weaviate.Client.Models;
+
+// Define collection properties
+var properties = new[]
+{
+    Property.Text("title", indexSearchable: true),
+    Property.Text("content", indexSearchable: true),
+    Property.Int("wordCount", indexFilterable: true),
+    Property.Date("publishedAt", indexFilterable: true),
+    Property.TextArray("tags"),
+    Property.Bool("featured")
+};
+
+var references = new[]
+{
+    new Reference("author", "Author", "Article author"),
+    new Reference("category", "Category", "Article category")
+};
+
+// Use in collection creation
+await client.Collections.CreateAsync(new CollectionConfig
+{
+    Name = "Article",
+    Properties = properties,
+    References = references
+});
+```
+
+### Automatic Property Extraction from Classes
+
+The `Property.FromClass<T>()` method automatically extracts properties from C# classes:
+
+```csharp
+public class Article
+{
+    public string Title { get; set; }
+    public string Content { get; set; }
+    public int WordCount { get; set; }
+    public DateTime PublishedAt { get; set; }
+    public List<string> Tags { get; set; }
+    public bool Featured { get; set; }
+}
+
+// Automatically generates properties based on class structure
+var properties = Property.FromClass<Article>();
+
+// Equivalent to:
+// [
+//     new Property { Name = "title", DataType = DataType.Text },
+//     new Property { Name = "content", DataType = DataType.Text },
+//     new Property { Name = "wordCount", DataType = DataType.Int },
+//     new Property { Name = "publishedAt", DataType = DataType.Date },
+//     new Property { Name = "tags", DataType = DataType.TextArray },
+//     new Property { Name = "featured", DataType = DataType.Bool }
+// ]
+```
+
+### Nested Object Extraction
+
+For complex types with nested objects:
+
+```csharp
+public class Person
+{
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+    public Address HomeAddress { get; set; }  // Nested object
+}
+
+public class Address
+{
+    public string Street { get; set; }
+    public string City { get; set; }
+    public string Country { get; set; }
+}
+
+// Extract with nested properties (maxDepth = 1)
+var properties = Property.FromClass<Person>(maxDepth: 1);
+
+// Result:
+// [
+//     { Name = "firstName", DataType = DataType.Text },
+//     { Name = "lastName", DataType = DataType.Text },
+//     {
+//         Name = "homeAddress",
+//         DataType = DataType.Object,
+//         NestedProperties = [
+//             { Name = "street", DataType = DataType.Text },
+//             { Name = "city", DataType = DataType.Text },
+//             { Name = "country", DataType = DataType.Text }
+//         ]
+//     }
+// ]
+```
+
+The `maxDepth` parameter controls how many levels of nesting to extract:
+- `maxDepth: 0` - Only top-level properties, nested objects excluded
+- `maxDepth: 1` - One level of nesting (default)
+- `maxDepth: 2` - Two levels of nesting
+- And so on...
+
+### Combining Manual and Automatic
+
+```csharp
+// Start with automatic extraction
+var properties = Property.FromClass<Article>().ToList();
+
+// Add custom indexing configuration
+properties.Add(Property.Text(
+    "searchableTitle",
+    indexSearchable: true,
+    indexFilterable: true,
+    tokenization: PropertyTokenization.Word
+));
+
+// Add references (not extracted from classes)
+var references = new[]
+{
+    new Reference("author", "Author"),
+    new Reference("category", "Category")
+};
+```
+
+## Serialization
+
+### Property Serialization (ToDto)
+
+Properties serialize to the Weaviate REST DTO format:
+
+```csharp
+// Internal model
+var property = new Property
+{
+    Name = "title",
+    DataType = DataType.Text,
+    Description = "Article title",
+    IndexSearchable = true,
+    IndexFilterable = true
+};
+
+// Serialized to DTO
+var dto = property.ToDto();
+// Result:
+// {
+//     "name": "title",
+//     "dataType": ["text"],  // Enum converted to string in array
+//     "description": "Article title",
+//     "indexSearchable": true,
+//     "indexFilterable": true
+// }
+```
+
+### Reference Serialization (ToDto)
+
+References serialize similarly but use the target collections list:
+
+```csharp
+var reference = new Reference("author", "Author", "Article author");
+
+var dto = reference.ToDto();
+// Result:
+// {
+//     "name": "author",
+//     "dataType": ["Author"],  // Collection name as string
+//     "description": "Article author"
+// }
+```
+
+### Deserialization (ToModel / ToReference)
+
+The DTO can deserialize back to either Property or Reference based on the dataType content:
+
+```csharp
+// DTO from server
+var dto = new Rest.Dto.Property
+{
+    Name = "title",
+    DataType = ["text"],
+    Description = "Article title",
+    IndexSearchable = true
+};
+
+// Deserialize to Property (lowercase dataType)
+var property = dto.ToModel();
+// Result: Property with DataType = DataType.Text
+
+// DTO for reference
+var refDto = new Rest.Dto.Property
+{
+    Name = "author",
+    DataType = ["Author"],  // Uppercase = collection name
+    Description = "Article author"
+};
+
+// Deserialize to Reference
+var reference = refDto.ToReference();
+// Result: Reference with TargetCollections = ["Author"]
+```
+
+### Separation Logic
+
+The client distinguishes Properties from References based on the first character of the dataType string:
+
+```csharp
+// In CollectionConfig conversion:
+References = collection?.Properties
+    ?.Where(p => p.DataType?.Any(t => char.IsUpper(t.First())) ?? false)
+    .Select(p => p.ToReference())
+    .ToArray() ?? [];
+
+Properties = collection?.Properties
+    ?.Where(p => p.DataType?.All(t => char.IsLower(t.First())) ?? false)
+    .Select(p => p.ToModel())
+    .ToArray() ?? [];
+```
+
+- **Uppercase first character** → Reference (e.g., "Author", "Category")
+- **Lowercase first character** → Property (e.g., "text", "int", "boolean[]")
+
+## Type Inference
+
+### PropertyHelper Class
+
+The `PropertyHelper` class provides automatic type inference from C# types to DataType enum values:
+
+```csharp
+// Get DataType for any C# type
+DataType stringType = PropertyHelper.DataTypeForType(typeof(string));
+// Returns: DataType.Text
+
+DataType intListType = PropertyHelper.DataTypeForType(typeof(List<int>));
+// Returns: DataType.IntArray
+
+DataType customType = PropertyHelper.DataTypeForType(typeof(MyClass));
+// Returns: DataType.Object
+```
+
+### Special Type Handling
+
+#### Nullable Types
+```csharp
+DataType nullableInt = PropertyHelper.DataTypeForType(typeof(int?));
+// Returns: DataType.Int (nullable wrapper removed)
+
+DataType nullableDateTime = PropertyHelper.DataTypeForType(typeof(DateTime?));
+// Returns: DataType.Date
+```
+
+#### Enums
+```csharp
+public enum Status { Active, Inactive, Pending }
+
+DataType enumType = PropertyHelper.DataTypeForType(typeof(Status));
+// Returns: DataType.Text (enums serialize as strings)
+
+DataType enumArrayType = PropertyHelper.DataTypeForType(typeof(Status[]));
+// Returns: DataType.TextArray
+```
+
+#### Collections
+```csharp
+// Arrays
+PropertyHelper.DataTypeForType(typeof(string[]));  // DataType.TextArray
+PropertyHelper.DataTypeForType(typeof(int[]));     // DataType.IntArray
+
+// Lists
+PropertyHelper.DataTypeForType(typeof(List<string>));  // DataType.TextArray
+PropertyHelper.DataTypeForType(typeof(List<int>));     // DataType.IntArray
+
+// IEnumerable
+PropertyHelper.DataTypeForType(typeof(IEnumerable<bool>));  // DataType.BoolArray
+
+// HashSet
+PropertyHelper.DataTypeForType(typeof(HashSet<Guid>));  // DataType.UuidArray
+```
+
+#### Byte Arrays (Blob)
+```csharp
+PropertyHelper.DataTypeForType(typeof(byte[]));   // DataType.Blob
+PropertyHelper.DataTypeForType(typeof(sbyte[]));  // DataType.Blob
+```
+
+### PropertyFactory Delegate
+
+The `PropertyFactory` delegate provides a functional way to create properties:
+
+```csharp
+public delegate Property PropertyFactory(
+    string name,
+    string? description = null,
+    bool? indexFilterable = null,
+    bool? indexRangeFilters = null,
+    bool? indexSearchable = null,
+    PropertyTokenization? tokenization = null,
+    Property[]? subProperties = null
+);
+
+// Get factory for a specific type
+PropertyFactory textFactory = PropertyHelper.ForType(typeof(string));
+var title = textFactory("title", description: "Article title", indexSearchable: true);
+
+// Static factories use this pattern internally
+Property.Text("title") // Uses PropertyHelper.Factory(DataType.Text)
+```
+
+## Validation
+
+### TypeValidator
+
+The `TypeValidator` class validates C# types against Weaviate schema properties:
+
+```csharp
+// Validate a C# class against a collection schema
+public class Article
+{
+    public string Title { get; set; }  // Must match "title" property
+    public int WordCount { get; set; }  // Must match "wordCount" property
+}
+
+// Schema from Weaviate
+var schemaProperties = new[]
+{
+    new Property { Name = "title", DataType = DataType.Text },
+    new Property { Name = "wordCount", DataType = DataType.Int }
+};
+
+// Validation happens automatically when using typed client
+var collection = client.Collections.Get<Article>("Article");
+// TypeValidator ensures Article properties match schema
+```
+
+### Type Compatibility Rules
+
+The validator checks:
+
+1. **Property Name Matching** (case-insensitive after decapitalization)
+   ```csharp
+   // C# property: Title
+   // Schema property: title
+   // ✅ Match (after decapitalization)
+   ```
+
+2. **DataType Compatibility**
+   ```csharp
+   // C# type: string → Expected: DataType.Text
+   // Schema: DataType.Text
+   // ✅ Compatible
+
+   // C# type: int → Expected: DataType.Int
+   // Schema: DataType.Number
+   // ❌ Incompatible (different types)
+   ```
+
+3. **Enum-to-Int Special Case**
+   ```csharp
+   // C# type: enum → Expected: DataType.Text (enum serializes as string)
+   // Schema: DataType.Int
+   // ✅ Compatible (enums can be stored as ints in Weaviate)
+   ```
+
+4. **Nested Object Validation**
+   ```csharp
+   // C# has nested Address property
+   // Schema must have object type with nested properties
+   // Recursively validates nested properties
+   ```
+
+### Validation Errors
+
+When validation fails, a `WeaviateClientException` is thrown with details:
+
+```csharp
+try
+{
+    var collection = client.Collections.Get<Article>("Article");
+}
+catch (WeaviateClientException ex)
+{
+    // Message includes:
+    // - Mismatched property names
+    // - Type incompatibilities
+    // - Missing required properties
+}
+```
+
+## Advanced Topics
+
+### PropertyTokenization
+
+The `PropertyTokenization` enum controls how text properties are tokenized for search:
+
+```csharp
+public enum PropertyTokenization
+{
+    Word = 0,        // Split on non-alphanumeric characters
+    Lowercase = 1,   // Word tokenization + lowercase
+    Whitespace = 2,  // Split on whitespace only
+    Field = 3,       // Treat entire field as single token
+    Trigram = 4,     // Character trigrams for fuzzy search
+    Gse = 5,         // Chinese text segmentation
+    Kagome_kr = 6,   // Korean text segmentation
+    Kagome_ja = 7,   // Japanese text segmentation
+    Gse_ch = 8       // Chinese text segmentation (alternative)
+}
+
+// Usage:
+var property = Property.Text(
+    "title",
+    indexSearchable: true,
+    tokenization: PropertyTokenization.Word
+);
+```
+
+### Index Configuration
+
+Properties support several indexing options:
+
+```csharp
+var property = new Property
+{
+    Name = "title",
+    DataType = DataType.Text,
+
+    // Enable/disable filtering support
+    IndexFilterable = true,  // Allow WHERE filters
+
+    // Enable/disable range filters (>, <, >=, <=)
+    IndexRangeFilters = true,  // Allow range queries
+
+    // Enable/disable full-text search
+    IndexSearchable = true,  // Allow BM25/keyword search
+
+    // Control tokenization (when IndexSearchable = true)
+    PropertyTokenization = PropertyTokenization.Word
+};
+```
+
+#### Index Configuration Guidelines
+
+- **IndexFilterable**: Set to `true` for properties used in filters (`where name = "value"`)
+- **IndexRangeFilters**: Set to `true` for numeric/date range queries (`where count > 10`)
+- **IndexSearchable**: Set to `true` for text properties used in BM25/keyword search
+- **PropertyTokenization**: Only applies when `IndexSearchable = true`
+
+Example configurations:
+
+```csharp
+// ID field - filter only, no search
+Property.Text("id", indexFilterable: true, indexSearchable: false)
+
+// Title - both filterable and searchable
+Property.Text("title",
+    indexFilterable: true,
+    indexSearchable: true,
+    tokenization: PropertyTokenization.Word
+)
+
+// Counter - filterable with range support
+Property.Int("count",
+    indexFilterable: true,
+    indexRangeFilters: true
+)
+
+// Timestamp - filterable with range support
+Property.Date("createdAt",
+    indexFilterable: true,
+    indexRangeFilters: true
+)
+
+// Tags - searchable only
+Property.TextArray("tags",
+    indexSearchable: true,
+    tokenization: PropertyTokenization.Lowercase
+)
+```
+
+### Circular Reference Detection
+
+When using `Property.FromClass<T>()` with nested objects, the system prevents infinite recursion:
+
+```csharp
+public class Person
+{
+    public string Name { get; set; }
+    public Person? Parent { get; set; }  // Circular reference!
+}
+
+// Extracts with maxDepth to prevent infinite loop
+var properties = Property.FromClass<Person>(maxDepth: 2);
+// Only extracts Person.Parent.Parent (2 levels deep), then stops
+```
+
+The `seenTypes` dictionary tracks visited types to prevent processing the same type multiple times in a single path.
+
+### Custom Property Converters
+
+For advanced scenarios, you can implement custom property converters:
+
+```csharp
+// PropertyConverterRegistry tracks converters by DataType string
+// This is used during serialization/deserialization
+
+// Custom converter example (internal use)
+var registry = new PropertyConverterRegistry();
+registry.Register("custom-type", new CustomPropertyConverter());
+```
+
+This is typically used internally by the client and not exposed for direct use.
+
+### Property Equality and Hashing
+
+Properties implement proper equality and hash code generation:
+
+```csharp
+var prop1 = Property.Text("title");
+var prop2 = Property.Text("title");
+
+// Equality checks all fields
+Console.WriteLine(prop1.Equals(prop2));  // true
+Console.WriteLine(prop1 == prop2);       // true (record equality)
+
+// Hash code based on all fields
+var set = new HashSet<Property> { prop1, prop2 };
+Console.WriteLine(set.Count);  // 1 (duplicates removed)
+```
+
+Hash code generation includes:
+- Name
+- DataType
+- Description
+- All index settings
+- PropertyTokenization
+- NestedProperties (recursively)
+
+## Best Practices
+
+### 1. Use Type Inference When Possible
+
+```csharp
+// ✅ Preferred: Type-safe automatic inference
+var properties = Property.FromClass<Article>();
+
+// ⚠️ Less preferred: Manual definition (more verbose, error-prone)
+var properties = new[]
+{
+    Property.Text("title"),
+    Property.Int("wordCount"),
+    // ...
+};
+```
+
+### 2. Configure Indexes Based on Usage
+
+```csharp
+// ✅ Correct: Index configuration matches query patterns
+Property.Text("title",
+    indexSearchable: true,      // Used in BM25 search
+    indexFilterable: true       // Used in WHERE filters
+)
+
+// ❌ Incorrect: Over-indexing (wastes space)
+Property.Blob("image",
+    indexSearchable: true,      // Blobs can't be searched!
+    indexFilterable: true       // Rarely filtered
+)
+```
+
+### 3. Use References for Relationships
+
+```csharp
+// ✅ Correct: Use Reference for relationships
+new Reference("author", "Author")
+
+// ❌ Incorrect: Don't use string property for references
+Property.Text("authorId")  // Loses relationship semantics
+```
+
+### 4. Leverage Static Factories
+
+```csharp
+// ✅ Preferred: Clean, readable
+var title = Property.Text("title", indexSearchable: true);
+
+// ⚠️ Less preferred: More verbose
+var title = new Property
+{
+    Name = "title",
+    DataType = DataType.Text,
+    IndexSearchable = true
+};
+```
+
+### 5. Use maxDepth for Complex Nesting
+
+```csharp
+// ✅ Correct: Control nesting depth
+var properties = Property.FromClass<ComplexType>(maxDepth: 2);
+
+// ⚠️ Warning: May extract too much or too little
+var properties = Property.FromClass<ComplexType>();  // Default maxDepth: 1
+```
+
+### 6. Name Properties Consistently
+
+```csharp
+// ✅ Correct: PascalCase in C#, auto-decapitalized
+public class Article
+{
+    public string Title { get; set; }        // Becomes "title"
+    public int WordCount { get; set; }       // Becomes "wordCount"
+}
+
+// ⚠️ Less ideal: Manual lowercase (inconsistent)
+public class Article
+{
+    public string title { get; set; }        // Already lowercase
+}
+```
+
+The client automatically handles decapitalization, so follow C# naming conventions.
+
+## Examples
+
+### Complete Collection Setup
+
+```csharp
+using Weaviate.Client;
+using Weaviate.Client.Models;
+
+// Define model
+public class BlogPost
+{
+    public string Title { get; set; }
+    public string Content { get; set; }
+    public DateTime PublishedAt { get; set; }
+    public int Views { get; set; }
+    public List<string> Tags { get; set; }
+    public bool Featured { get; set; }
+}
+
+// Create collection with automatic property extraction
+var collection = await client.Collections.CreateAsync(new CollectionConfig
+{
+    Name = "BlogPost",
+
+    // Automatically extract properties from BlogPost class
+    Properties = Property.FromClass<BlogPost>(),
+
+    // Add references manually
+    References = new[]
+    {
+        new Reference("author", "Author", "Blog post author"),
+        new Reference("category", "Category", "Blog post category")
+    }
+});
+```
+
+### Manual Configuration with Indexing
+
+```csharp
+var collection = await client.Collections.CreateAsync(new CollectionConfig
+{
+    Name = "Product",
+
+    Properties = new[]
+    {
+        // Searchable title
+        Property.Text("name",
+            description: "Product name",
+            indexSearchable: true,
+            indexFilterable: true,
+            tokenization: PropertyTokenization.Word
+        ),
+
+        // Searchable description
+        Property.Text("description",
+            description: "Product description",
+            indexSearchable: true,
+            tokenization: PropertyTokenization.Word
+        ),
+
+        // Filterable SKU
+        Property.Text("sku",
+            description: "Stock keeping unit",
+            indexFilterable: true,
+            indexSearchable: false
+        ),
+
+        // Range-filterable price
+        Property.Number("price",
+            description: "Product price",
+            indexFilterable: true,
+            indexRangeFilters: true
+        ),
+
+        // Range-filterable stock
+        Property.Int("stockQuantity",
+            description: "Available quantity",
+            indexFilterable: true,
+            indexRangeFilters: true
+        ),
+
+        // Filterable category
+        Property.TextArray("categories",
+            description: "Product categories",
+            indexFilterable: true
+        )
+    },
+
+    References = new[]
+    {
+        new Reference("manufacturer", "Manufacturer"),
+        new Reference("supplier", "Supplier")
+    }
+});
+```
+
+### Complex Nested Objects
+
+```csharp
+public class Order
+{
+    public string OrderId { get; set; }
+    public DateTime OrderDate { get; set; }
+    public Customer Customer { get; set; }
+    public List<LineItem> Items { get; set; }
+}
+
+public class Customer
+{
+    public string Name { get; set; }
+    public string Email { get; set; }
+    public Address ShippingAddress { get; set; }
+}
+
+public class Address
+{
+    public string Street { get; set; }
+    public string City { get; set; }
+    public string Country { get; set; }
+}
+
+public class LineItem
+{
+    public string ProductName { get; set; }
+    public int Quantity { get; set; }
+    public decimal Price { get; set; }
+}
+
+// Extract with 3 levels of nesting
+// Level 0: Order
+// Level 1: Customer, Items[]
+// Level 2: ShippingAddress, (LineItem properties)
+// Level 3: (Address properties)
+var properties = Property.FromClass<Order>(maxDepth: 3);
+
+// Result structure:
+// - orderId: text
+// - orderDate: date
+// - customer: object
+//   - name: text
+//   - email: text
+//   - shippingAddress: object
+//     - street: text
+//     - city: text
+//     - country: text
+// - items: object[]
+//   - productName: text
+//   - quantity: int
+//   - price: number
+```
+
+## Migration Guide
+
+If upgrading from a version that used string-based DataType:
+
+### Before (String-Based)
+
+```csharp
+// Old string-based approach
+new Property
+{
+    Name = "title",
+    DataType = { "text" },  // Collection of strings
+    IndexSearchable = true
+}
+
+// Old static constants
+if (property.DataType.Contains(DataType.Text))  // String comparison
+```
+
+### After (Enum-Based)
+
+```csharp
+// New enum-based approach
+new Property
+{
+    Name = "title",
+    DataType = DataType.Text,  // Single enum value
+    IndexSearchable = true
+}
+
+// New enum comparison
+if (property.DataType == DataType.Text)  // Type-safe comparison
+```
+
+### Breaking Changes
+
+1. `Property.DataType` changed from `IList<string>` to `DataType` enum
+2. Constructor signature changed from `Property(string name, string dataType)` to `Property(string name, DataType dataType)`
+3. No implicit conversion between Reference and Property
+
+### Migration Steps
+
+1. Update Property instantiations:
+   ```csharp
+   // Before:
+   new Property { Name = "title", DataType = ["text"] }
+
+   // After:
+   new Property { Name = "title", DataType = DataType.Text }
+   ```
+
+2. Update comparisons:
+   ```csharp
+   // Before:
+   if (property.DataType.Contains("text"))
+   if (property.DataType[0] == DataType.Text)
+
+   // After:
+   if (property.DataType == DataType.Text)
+   ```
+
+3. Static factories remain unchanged:
+   ```csharp
+   // Still works:
+   Property.Text("title")
+   Property<string>.New("title")
+   ```
+
+## Conclusion
+
+The Property system provides a robust, type-safe way to define collection schemas in the Weaviate C# client. Key takeaways:
+
+- **Type Safety**: Enum-based DataType prevents typos and provides compile-time checking
+- **Flexibility**: Manual definition or automatic extraction from C# classes
+- **Clear Semantics**: Distinct Property (single type) and Reference (relationships) models
+- **Wire Compatibility**: EnumMember attributes ensure correct REST API serialization
+- **Automatic Type Inference**: PropertyHelper maps C# types to Weaviate types
+- **Validation**: TypeValidator ensures C# classes match Weaviate schemas
+
+For questions or issues, please refer to the main Weaviate documentation or file an issue in the GitHub repository.

--- a/src/Weaviate.Client.Tests/Integration/TestCollections.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestCollections.cs
@@ -182,7 +182,7 @@ public partial class CollectionsTests : IntegrationTests
         Assert.Single(export.Properties);
         var property = export.Properties.First();
         Assert.Equal("name", property.Name);
-        Assert.Contains("text", property.DataType);
+        Assert.Equal(DataType.Text, property.DataType);
 
         // InvertedIndexConfig validation
         Assert.NotNull(export.InvertedIndexConfig);
@@ -341,7 +341,7 @@ public partial class CollectionsTests : IntegrationTests
         Assert.Equal(2, export.Properties.Length);
         var property = export.Properties.First();
         Assert.Equal("name", property.Name);
-        Assert.Contains("text", property.DataType);
+        Assert.Equal(DataType.Text, property.DataType);
 
         // InvertedIndexConfig validation
         Assert.NotNull(export.InvertedIndexConfig);
@@ -500,7 +500,7 @@ public partial class CollectionsTests : IntegrationTests
         Assert.Equal(2, export.Properties.Length);
         var property = export.Properties.First();
         Assert.Equal("name", property.Name);
-        Assert.Contains("text", property.DataType);
+        Assert.Equal(DataType.Text, property.DataType);
 
         // InvertedIndexConfig validation
         Assert.NotNull(export.InvertedIndexConfig);

--- a/src/Weaviate.Client.Tests/Integration/TestProperties.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestProperties.cs
@@ -209,7 +209,7 @@ public partial class PropertyTests : IntegrationTests
 
         foreach (var actual in new[] { actualSingle, actualBatch })
         {
-            if (props[0].DataType.Contains(DataType.Blob))
+            if (props[0].DataType == DataType.Blob)
             {
                 Assert.IsType<string>(actual);
                 string actualString = (string)actual!;
@@ -241,7 +241,7 @@ public partial class PropertyTests : IntegrationTests
                     Assert.Equal(exp, act, 5);
                 }
             }
-            else if (props[0].DataType.Contains(DataType.Blob) && actual is string actualString)
+            else if (props[0].DataType == DataType.Blob && actual is string actualString)
             {
                 var actualBytes = Convert.FromBase64String(actualString);
                 Assert.Equal(expected, actualBytes);

--- a/src/Weaviate.Client.Tests/Integration/TypedClientIntegrationTests.cs
+++ b/src/Weaviate.Client.Tests/Integration/TypedClientIntegrationTests.cs
@@ -41,10 +41,10 @@ public class TypedClientIntegrationTests : IntegrationTests
         Name = "Articles",
         Properties = new[]
         {
-            new Property { Name = "title", DataType = new[] { "text" } },
-            new Property { Name = "content", DataType = new[] { "text" } },
-            new Property { Name = "viewCount", DataType = new[] { "int" } },
-            new Property { Name = "publishedDate", DataType = new[] { "date" } },
+            new Property { Name = "title", DataType = DataType.Text },
+            new Property { Name = "content", DataType = DataType.Text },
+            new Property { Name = "viewCount", DataType = DataType.Int },
+            new Property { Name = "publishedDate", DataType = DataType.Date },
         },
     };
 

--- a/src/Weaviate.Client.Tests/Integration/UntypedDataClientValidationIntegrationTests.cs
+++ b/src/Weaviate.Client.Tests/Integration/UntypedDataClientValidationIntegrationTests.cs
@@ -16,8 +16,16 @@ namespace Weaviate.Client.Tests.Integration
             Name = "People",
             Properties = new[]
             {
-                new Weaviate.Client.Models.Property { Name = "name", DataType = new[] { "text" } },
-                new Weaviate.Client.Models.Property { Name = "age", DataType = new[] { "int" } },
+                new Weaviate.Client.Models.Property
+                {
+                    Name = "name",
+                    DataType = Weaviate.Client.Models.DataType.Text,
+                },
+                new Weaviate.Client.Models.Property
+                {
+                    Name = "age",
+                    DataType = Weaviate.Client.Models.DataType.Int,
+                },
             },
         };
 

--- a/src/Weaviate.Client.Tests/Integration/_Integration.cs
+++ b/src/Weaviate.Client.Tests/Integration/_Integration.cs
@@ -177,7 +177,8 @@ public abstract partial class IntegrationTests : IAsyncDisposable, IAsyncLifetim
         {
             Name = name,
             Description = description,
-            Properties = properties?.Concat(references!.Select(p => (Property)p)).ToArray() ?? [],
+            Properties = properties?.ToArray() ?? [],
+            References = references?.ToArray() ?? [],
             VectorConfig = vectorConfig,
             MultiTenancyConfig = multiTenancyConfig,
             InvertedIndexConfig = invertedIndexConfig,

--- a/src/Weaviate.Client.Tests/Unit/TestProperties.cs
+++ b/src/Weaviate.Client.Tests/Unit/TestProperties.cs
@@ -41,10 +41,8 @@ public partial class PropertyTests
     public void Equals_Should_Return_True_For_Identical_Properties()
     {
         // Arrange
-        var property1 = new Property
+        var property1 = new Property("name", DataType.Text)
         {
-            Name = "name",
-            DataType = { "text" },
             Description = "description",
             IndexFilterable = true,
             IndexRangeFilters = false,
@@ -52,10 +50,8 @@ public partial class PropertyTests
             PropertyTokenization = PropertyTokenization.Whitespace,
         };
 
-        var property2 = new Property
+        var property2 = new Property("name", DataType.Text)
         {
-            Name = "name",
-            DataType = { "text" },
             Description = "description",
             IndexFilterable = true,
             IndexRangeFilters = false,
@@ -74,8 +70,8 @@ public partial class PropertyTests
     public void Equals_Should_Return_False_When_Names_Differ()
     {
         // Arrange
-        var property1 = new Property { Name = "name1" };
-        var property2 = new Property { Name = "name2" };
+        var property1 = new Property("name1", DataType.Text);
+        var property2 = new Property("name2", DataType.Text);
 
         // Act
         var result = property1.Equals(property2);
@@ -88,8 +84,8 @@ public partial class PropertyTests
     public void Equals_Should_Return_False_When_DataTypes_Differ()
     {
         // Arrange
-        var property1 = new Property { Name = "prop", DataType = { "text" } };
-        var property2 = new Property { Name = "prop", DataType = { "int" } };
+        var property1 = new Property("prop", DataType.Text);
+        var property2 = new Property("prop", DataType.Int);
 
         // Act
         var result = property1.Equals(property2);
@@ -102,8 +98,8 @@ public partial class PropertyTests
     public void Equals_Should_Return_False_When_Descriptions_Differ()
     {
         // Arrange
-        var property1 = new Property { Name = "prop", Description = "desc1" };
-        var property2 = new Property { Name = "prop", Description = "desc2" };
+        var property1 = new Property("prop", DataType.Text) { Description = "desc1" };
+        var property2 = new Property("prop", DataType.Text) { Description = "desc2" };
 
         // Act
         var result = property1.Equals(property2);
@@ -116,8 +112,8 @@ public partial class PropertyTests
     public void Equals_Should_Return_False_When_IndexFilterable_Differs()
     {
         // Arrange
-        var property1 = new Property { Name = "prop", IndexFilterable = true };
-        var property2 = new Property { Name = "prop", IndexFilterable = false };
+        var property1 = new Property("prop", DataType.Text) { IndexFilterable = true };
+        var property2 = new Property("prop", DataType.Text) { IndexFilterable = false };
 
         // Act
         var result = property1.Equals(property2);
@@ -130,8 +126,8 @@ public partial class PropertyTests
     public void Equals_Should_Return_False_When_IndexRangeFilters_Differs()
     {
         // Arrange
-        var property1 = new Property { Name = "prop", IndexRangeFilters = true };
-        var property2 = new Property { Name = "prop", IndexRangeFilters = false };
+        var property1 = new Property("prop", DataType.Text) { IndexRangeFilters = true };
+        var property2 = new Property("prop", DataType.Text) { IndexRangeFilters = false };
 
         // Act
         var result = property1.Equals(property2);
@@ -144,8 +140,8 @@ public partial class PropertyTests
     public void Equals_Should_Return_False_When_IndexSearchable_Differs()
     {
         // Arrange
-        var property1 = new Property { Name = "prop", IndexSearchable = true };
-        var property2 = new Property { Name = "prop", IndexSearchable = false };
+        var property1 = new Property("prop", DataType.Text) { IndexSearchable = true };
+        var property2 = new Property("prop", DataType.Text) { IndexSearchable = false };
 
         // Act
         var result = property1.Equals(property2);
@@ -158,14 +154,12 @@ public partial class PropertyTests
     public void Equals_Should_Return_False_When_PropertyTokenization_Differs()
     {
         // Arrange
-        var property1 = new Property
+        var property1 = new Property("prop", DataType.Text)
         {
-            Name = "prop",
             PropertyTokenization = PropertyTokenization.Word,
         };
-        var property2 = new Property
+        var property2 = new Property("prop", DataType.Text)
         {
-            Name = "prop",
             PropertyTokenization = PropertyTokenization.Lowercase,
         };
 
@@ -205,16 +199,10 @@ public partial class PropertyTests
         // Assert
         Assert.Equal(4, properties.Length);
 
-        Assert.Contains(properties, p => p.Name == "name" && p.DataType.Contains(DataType.Text));
-        Assert.Contains(properties, p => p.Name == "age" && p.DataType.Contains(DataType.Int));
-        Assert.Contains(
-            properties,
-            p => p.Name == "isActive" && p.DataType.Contains(DataType.Bool)
-        );
-        Assert.Contains(
-            properties,
-            p => p.Name == "createdAt" && p.DataType.Contains(DataType.Date)
-        );
+        Assert.Contains(properties, p => p.Name == "name" && p.DataType == DataType.Text);
+        Assert.Contains(properties, p => p.Name == "age" && p.DataType == DataType.Int);
+        Assert.Contains(properties, p => p.Name == "isActive" && p.DataType == DataType.Bool);
+        Assert.Contains(properties, p => p.Name == "createdAt" && p.DataType == DataType.Date);
     }
 
     [Fact]
@@ -248,25 +236,22 @@ public partial class PropertyTests
         // Assert
         Assert.Equal(3, properties.Length);
 
-        Assert.Contains(properties, p => p.Name == "title" && p.DataType.Contains(DataType.Text));
+        Assert.Contains(properties, p => p.Name == "title" && p.DataType == DataType.Text);
+        Assert.Contains(properties, p => p.Name == "details" && p.DataType == DataType.Object);
         Assert.Contains(
             properties,
-            p => p.Name == "details" && p.DataType.Contains(DataType.Object)
-        );
-        Assert.Contains(
-            properties,
-            p => p.Name == "detailsArray" && p.DataType.Contains(DataType.ObjectArray)
+            p => p.Name == "detailsArray" && p.DataType == DataType.ObjectArray
         );
         var detailsProperty = properties.FirstOrDefault(p => p.Name == "details");
         Assert.NotNull(detailsProperty);
-        Assert.Equal(DataType.Object, detailsProperty!.DataType[0]);
+        Assert.Equal(DataType.Object, detailsProperty!.DataType);
         Assert.NotNull(detailsProperty!.NestedProperties);
         Assert.NotEmpty(detailsProperty.NestedProperties);
         Assert.Null(detailsProperty.NestedProperties[0].NestedProperties);
 
         var detailsArrayProperty = properties.FirstOrDefault(p => p.Name == "detailsArray");
         Assert.NotNull(detailsArrayProperty);
-        Assert.Equal(DataType.ObjectArray, detailsArrayProperty!.DataType[0]);
+        Assert.Equal(DataType.ObjectArray, detailsArrayProperty!.DataType);
         Assert.NotNull(detailsArrayProperty!.NestedProperties);
         Assert.NotEmpty(detailsArrayProperty.NestedProperties);
         Assert.Null(detailsArrayProperty.NestedProperties[0].NestedProperties);

--- a/src/Weaviate.Client.Tests/Unit/TestTypeValidator.cs
+++ b/src/Weaviate.Client.Tests/Unit/TestTypeValidator.cs
@@ -17,9 +17,9 @@ public class TypeValidatorTests
             Name = "Article",
             Properties =
             [
-                new Property { Name = "title", DataType = [DataType.Text] },
-                new Property { Name = "publishedDate", DataType = [DataType.Date] },
-                new Property { Name = "viewCount", DataType = [DataType.Int] },
+                new Property { Name = "title", DataType = DataType.Text },
+                new Property { Name = "publishedDate", DataType = DataType.Date },
+                new Property { Name = "viewCount", DataType = DataType.Int },
             ],
         };
 
@@ -42,7 +42,7 @@ public class TypeValidatorTests
             Name = "Article",
             Properties =
             [
-                new Property { Name = "viewCount", DataType = [DataType.Text] }, // Wrong: should be int
+                new Property { Name = "viewCount", DataType = DataType.Text }, // Wrong: should be int
             ],
         };
 
@@ -56,8 +56,8 @@ public class TypeValidatorTests
         Assert.Single(result.Errors);
         Assert.Equal(ValidationErrorType.TypeMismatch, result.Errors[0].ErrorType);
         Assert.Equal("ViewCount", result.Errors[0].PropertyName);
-        Assert.Equal(DataType.Text, result.Errors[0].ExpectedType);
-        Assert.Equal(DataType.Int, result.Errors[0].ActualType);
+        Assert.Equal("text", result.Errors[0].ExpectedType);
+        Assert.Equal("int", result.Errors[0].ActualType);
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public class TypeValidatorTests
                 new Property
                 {
                     Name = "tags",
-                    DataType = [DataType.Text], // Should be text[]
+                    DataType = DataType.Text, // Should be text[]
                 },
             ],
         };
@@ -97,7 +97,7 @@ public class TypeValidatorTests
             Name = "Article",
             Properties =
             [
-                new Property { Name = "title", DataType = [DataType.Text] },
+                new Property { Name = "title", DataType = DataType.Text },
                 // viewCount is in C# type but not in schema
             ],
         };
@@ -128,8 +128,8 @@ public class TypeValidatorTests
             Name = "Article",
             Properties =
             [
-                new Property { Name = "title", DataType = [DataType.Text] },
-                new Property { Name = "content", DataType = [DataType.Text] }, // Not in C# type
+                new Property { Name = "title", DataType = DataType.Text },
+                new Property { Name = "content", DataType = DataType.Text }, // Not in C# type
             ],
         };
 
@@ -153,18 +153,18 @@ public class TypeValidatorTests
             Name = "AllTypes",
             Properties =
             [
-                new Property { Name = "textProp", DataType = [DataType.Text] },
-                new Property { Name = "intProp", DataType = [DataType.Int] },
-                new Property { Name = "numberProp", DataType = [DataType.Number] },
-                new Property { Name = "boolProp", DataType = [DataType.Bool] },
-                new Property { Name = "dateProp", DataType = [DataType.Date] },
-                new Property { Name = "uuidProp", DataType = [DataType.Uuid] },
-                new Property { Name = "blobProp", DataType = [DataType.Blob] },
-                new Property { Name = "geoProp", DataType = [DataType.GeoCoordinate] },
-                new Property { Name = "phoneProp", DataType = [DataType.PhoneNumber] },
-                new Property { Name = "textArrayProp", DataType = [DataType.TextArray] },
-                new Property { Name = "intArrayProp", DataType = [DataType.IntArray] },
-                new Property { Name = "objectProp", DataType = [DataType.Object] },
+                new Property { Name = "textProp", DataType = DataType.Text },
+                new Property { Name = "intProp", DataType = DataType.Int },
+                new Property { Name = "numberProp", DataType = DataType.Number },
+                new Property { Name = "boolProp", DataType = DataType.Bool },
+                new Property { Name = "dateProp", DataType = DataType.Date },
+                new Property { Name = "uuidProp", DataType = DataType.Uuid },
+                new Property { Name = "blobProp", DataType = DataType.Blob },
+                new Property { Name = "geoProp", DataType = DataType.GeoCoordinate },
+                new Property { Name = "phoneProp", DataType = DataType.PhoneNumber },
+                new Property { Name = "textArrayProp", DataType = DataType.TextArray },
+                new Property { Name = "intArrayProp", DataType = DataType.IntArray },
+                new Property { Name = "objectProp", DataType = DataType.Object },
             ],
         };
 
@@ -187,15 +187,15 @@ public class TypeValidatorTests
             Name = "ArticleWithAuthor",
             Properties =
             [
-                new Property { Name = "title", DataType = [DataType.Text] },
+                new Property { Name = "title", DataType = DataType.Text },
                 new Property
                 {
                     Name = "author",
-                    DataType = [DataType.Object],
+                    DataType = DataType.Object,
                     NestedProperties =
                     [
-                        new Property { Name = "name", DataType = [DataType.Text] },
-                        new Property { Name = "age", DataType = [DataType.Int] },
+                        new Property { Name = "name", DataType = DataType.Text },
+                        new Property { Name = "age", DataType = DataType.Int },
                     ],
                 },
             ],
@@ -220,15 +220,15 @@ public class TypeValidatorTests
             Name = "ArticleWithAuthor",
             Properties =
             [
-                new Property { Name = "title", DataType = [DataType.Text] },
+                new Property { Name = "title", DataType = DataType.Text },
                 new Property
                 {
                     Name = "author",
-                    DataType = [DataType.Object],
+                    DataType = DataType.Object,
                     NestedProperties =
                     [
-                        new Property { Name = "name", DataType = [DataType.Text] },
-                        new Property { Name = "age", DataType = [DataType.Text] }, // Wrong: should be int
+                        new Property { Name = "name", DataType = DataType.Text },
+                        new Property { Name = "age", DataType = DataType.Text }, // Wrong: should be int
                     ],
                 },
             ],
@@ -396,7 +396,7 @@ public class TypeValidatorTests
         var schema = new CollectionConfig
         {
             Name = "Product",
-            Properties = [new Property { Name = "price", DataType = [DataType.Number] }],
+            Properties = [new Property { Name = "price", DataType = DataType.Number }],
         };
         var validator = TypeValidator.Default;
 
@@ -415,7 +415,7 @@ public class TypeValidatorTests
         var schema = new CollectionConfig
         {
             Name = "Order",
-            Properties = [new Property { Name = "quantity", DataType = [DataType.Int] }],
+            Properties = [new Property("quantity", DataType.Int)],
         };
         var validator = TypeValidator.Default;
 
@@ -436,11 +436,7 @@ public class TypeValidatorTests
             Name = "UserTask",
             Properties = new[]
             {
-                new Property
-                {
-                    Name = "status",
-                    DataType = new List<string> { DataType.Text },
-                },
+                new Property { Name = "status", DataType = DataType.Text },
             },
         };
         var validator = TypeValidator.Default;
@@ -462,11 +458,7 @@ public class TypeValidatorTests
             Name = "UserTask",
             Properties = new[]
             {
-                new Property
-                {
-                    Name = "status",
-                    DataType = new List<string> { DataType.Int },
-                },
+                new Property { Name = "status", DataType = DataType.Int },
             },
         };
         var validator = TypeValidator.Default;

--- a/src/Weaviate.Client/Models/Extensions.cs
+++ b/src/Weaviate.Client/Models/Extensions.cs
@@ -30,7 +30,7 @@ internal static class ModelsToDtoExtensions
         return new Rest.Dto.NestedProperty
         {
             Name = property.Name,
-            DataType = property.DataType?.ToList(),
+            DataType = [property.DataType.ToEnumMemberString()],
             Description = property.Description,
             IndexFilterable = property.IndexFilterable,
             IndexSearchable = property.IndexSearchable,
@@ -42,12 +42,24 @@ internal static class ModelsToDtoExtensions
         };
     }
 
+    internal static Rest.Dto.Property ToDto(this Models.Reference reference)
+    {
+        IReferenceBase refProp = reference;
+
+        return new Rest.Dto.Property
+        {
+            Name = refProp.Name,
+            DataType = refProp.TargetCollections,
+            Description = refProp.Description,
+        };
+    }
+
     internal static Rest.Dto.Property ToDto(this Models.Property property)
     {
         return new Rest.Dto.Property
         {
             Name = property.Name,
-            DataType = property.DataType?.ToList(),
+            DataType = [property.DataType.ToEnumMemberString()],
             Description = property.Description,
             IndexFilterable = property.IndexFilterable,
 #pragma warning disable CS0612 // Type or member is obsolete

--- a/src/Weaviate.Client/Models/Results.cs
+++ b/src/Weaviate.Client/Models/Results.cs
@@ -19,7 +19,7 @@ public record GroupByResult<TObject, TGroup>(
 
 public record WeaviateResult<TObject> : IEnumerable<TObject>
 {
-    public ICollection<TObject> Objects { get; init; } = Array.Empty<TObject>();
+    public IList<TObject> Objects { get; init; } = Array.Empty<TObject>();
 
     public IEnumerator<TObject> GetEnumerator() => Objects.GetEnumerator();
 

--- a/src/Weaviate.Client/Rest/Dto/Extensions.cs
+++ b/src/Weaviate.Client/Rest/Dto/Extensions.cs
@@ -51,7 +51,7 @@ internal partial record NestedProperty
         return new Models.Property
         {
             Name = Name ?? string.Empty,
-            DataType = DataType?.ToList() ?? new List<string>(),
+            DataType = DataType?.FirstOrDefault()?.FromEnumMemberString<Models.DataType>() ?? Models.DataType.Unknown,
             Description = Description,
             IndexFilterable = IndexFilterable,
             IndexSearchable = IndexSearchable,
@@ -62,13 +62,14 @@ internal partial record NestedProperty
     }
 }
 
-internal partial record Property {
-    public  Models.Property ToModel()
+internal partial record Property
+{
+    public Models.Property ToModel()
     {
         return new Models.Property
         {
             Name = Name ?? string.Empty,
-            DataType = DataType?.ToList() ?? new List<string>(),
+            DataType = DataType?.FirstOrDefault()?.FromEnumMemberString<Models.DataType>() ?? Models.DataType.Unknown,
             Description = Description,
             IndexFilterable = IndexFilterable,
 #pragma warning disable CS0612 // Type or member is obsolete
@@ -80,6 +81,13 @@ internal partial record Property {
             NestedProperties = NestedProperties?.Select(np => np.ToModel()).ToArray(),
         };
     }
+
+        public Models.Reference ToReferenceModel()
+        {
+            var targetCollection = DataType?.FirstOrDefault() ?? string.Empty;
+            return new Models.Reference(Name ?? string.Empty, targetCollection, Description);
+        }
+
 }
 
 internal partial record GeoCoordinates


### PR DESCRIPTION
Enhance the property creation process by restructuring data types.

### API Changes

1. **Property.DataType Type Changed**
   - **Before**: `IList<string> DataType { get; set; }`
   - **After**: `DataType DataType { get; set; }`

2. **Property Constructor Signature Changed**
   - **Before**: `Property(string Name, string DataType)` (implicit primary constructor)
   - **After**: `Property(string name, DataType dataType)` (explicit constructor)

3. **Implicit Conversion Operators Removed**
   - Removed implicit conversion between `Reference` and `Property`
   - These types now have distinct purposes and are serialized separately

4. **PropertyHelper Method Signatures Changed**
   - All methods now return `DataType` enum instead of `string`

### Migration Guide

Update Property instantiations:

```csharp
// Before:
new Property
{
    Name = "title",
    DataType = ["text"],
    IndexFilterable = true
}

new Property("title", "text") { IndexFilterable = true }

// After:
new Property
{
    Name = "title",
    DataType = DataType.Text,
    IndexFilterable = true
}

new Property("title", DataType.Text) { IndexFilterable = true }
```

Update DataType comparisons:

```csharp
// Before:
if (property.DataType.Contains("text"))
if (property.DataType[0] == DataType.Text)

// After:
if (property.DataType == DataType.Text)
```

Update static factory usage (no changes needed):

```csharp
// Still works the same:
Property.Text("title")
Property.Int("count")
Property<string>.New("name")
```

## Benefits

### Compile-Time Safety
- Typos in data types caught at compile time
- IDE autocomplete for all valid data types
- Refactoring tools can track DataType usage

### Clearer Semantics
- Property has single DataType enum (one type per property)
- Reference has IList<string> (multiple target collections)
- Clear architectural distinction between concepts