### PR TITLE
Remove unneeded parameters from db users create

### DIFF
--- a/src/Weaviate.Client/Rest/Users.cs
+++ b/src/Weaviate.Client/Rest/Users.cs
@@ -64,32 +64,14 @@ internal partial class WeaviateRestClient
 
     internal async Task<Dto.UserApiKey> UserDbCreate(
         string userId,
-        bool? import = null,
-        DateTimeOffset? createTime = null,
         CancellationToken cancellationToken = default
     )
     {
-        object? body = null;
-        if (import.HasValue || createTime.HasValue)
-        {
-            body = new
-            {
-                import = import ?? false,
-                createTime = createTime?.UtcDateTime.ToString("o"),
-            };
-        }
-        var response = body is not null
-            ? await _httpClient.PostAsJsonAsync(
-                WeaviateEndpoints.UserDb(userId),
-                body,
-                options: RestJsonSerializerOptions,
-                cancellationToken: cancellationToken
-            )
-            : await _httpClient.PostAsync(
-                WeaviateEndpoints.UserDb(userId),
-                null,
-                cancellationToken
-            );
+        var response = await _httpClient.PostAsync(
+            WeaviateEndpoints.UserDb(userId),
+            null,
+            cancellationToken
+        );
 
         await response.ManageStatusCode(
             [HttpStatusCode.Created],

--- a/src/Weaviate.Client/UsersDatabaseClient.cs
+++ b/src/Weaviate.Client/UsersDatabaseClient.cs
@@ -45,14 +45,9 @@ public class UsersDatabaseClient
     /// <summary>
     /// Creates a new database user and returns their API key.
     /// </summary>
-    public async Task<string> Create(
-        string userId,
-        bool? import = null,
-        DateTimeOffset? createTime = null,
-        CancellationToken cancellationToken = default
-    )
+    public async Task<string> Create(string userId, CancellationToken cancellationToken = default)
     {
-        var apiKey = await _client.RestClient.UserDbCreate(userId, import, createTime);
+        var apiKey = await _client.RestClient.UserDbCreate(userId, cancellationToken);
         return apiKey.Apikey;
     }
 


### PR DESCRIPTION
Extra parameters are for importing static API keys and are only used internally in WCD for migrations