### PR TITLE
Fix serialization of custom generative and reranker configurations

### DIFF
--- a/src/Weaviate.Client.Tests/Integration/TestCollections.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestCollections.cs
@@ -767,6 +767,9 @@ public partial class CollectionsTests : IntegrationTests
 
             c.MultiTenancyConfig.AutoTenantCreation = true;
             c.MultiTenancyConfig.AutoTenantActivation = true;
+
+            c.GenerativeConfig = Configure.Generative.Custom("generative-dummy");
+            c.RerankerConfig = Configure.Reranker.Custom("reranker-dummy");
         });
 
         // Assert - After first update

--- a/src/Weaviate.Client/Configure/GenerativeConfig.cs
+++ b/src/Weaviate.Client/Configure/GenerativeConfig.cs
@@ -10,7 +10,7 @@ public class GenerativeConfigFactory
     internal GenerativeConfigFactory() { }
 #pragma warning disable CA1822 // Mark members as static
     public IGenerativeConfig Custom(string type, object? config = null) =>
-        new GenerativeConfig.Custom { Type = type, Config = config };
+        new GenerativeConfig.Custom { Type = type, Config = config ?? new { } };
 
     public IGenerativeConfig AWSBedrock(
         string region,

--- a/src/Weaviate.Client/Configure/RerankerConfig.cs
+++ b/src/Weaviate.Client/Configure/RerankerConfig.cs
@@ -35,7 +35,7 @@ public class RerankerConfigFactory
         new Reranker.Nvidia { BaseURL = baseURL, Model = model };
 
     public IRerankerConfig Custom(string type, object? config = null) =>
-        new Reranker.Custom { Type = type, Config = config };
+        new Reranker.Custom { Type = type, Config = config ?? new { } };
 
     public IRerankerConfig None() => new Reranker.None();
 #pragma warning restore CA1822 // Mark members as static

--- a/src/Weaviate.Client/Models/GenerativeConfig.cs
+++ b/src/Weaviate.Client/Models/GenerativeConfig.cs
@@ -17,7 +17,7 @@ public static class GenerativeConfig
 
         public required string Type { get; set; }
 
-        public dynamic? Config { get; set; } = new { };
+        public object Config { get; set; } = new { };
     }
 
     public abstract record OpenAIBase : IGenerativeConfig

--- a/src/Weaviate.Client/Models/RerankerConfig.cs
+++ b/src/Weaviate.Client/Models/RerankerConfig.cs
@@ -116,7 +116,7 @@ public static class Reranker
 
         public required string Type { get; init; }
 
-        public dynamic? Config { get; set; }
+        public object Config { get; set; } = new { };
     }
 
     // Special case for "none" - no configuration needed

--- a/src/Weaviate.Client/Models/Serialization.GenerativeConfig.cs
+++ b/src/Weaviate.Client/Models/Serialization.GenerativeConfig.cs
@@ -10,88 +10,92 @@ internal static class GenerativeConfigSerialization
 
         if (config is JsonElement vic)
         {
+            var text = vic.GetRawText();
+
             var result = type switch
             {
                 GenerativeConfig.Anthropic.TypeValue => (IGenerativeConfig?)
                     JsonSerializer.Deserialize<GenerativeConfig.Anthropic>(
-                        vic.GetRawText(),
+                        text,
                         Rest.WeaviateRestClient.RestJsonSerializerOptions
                     ),
                 GenerativeConfig.Anyscale.TypeValue =>
                     JsonSerializer.Deserialize<GenerativeConfig.Anyscale>(
-                        vic.GetRawText(),
+                        text,
                         Rest.WeaviateRestClient.RestJsonSerializerOptions
                     ),
                 GenerativeConfig.AWS.TypeValue => JsonSerializer.Deserialize<GenerativeConfig.AWS>(
-                    vic.GetRawText(),
+                    text,
                     Rest.WeaviateRestClient.RestJsonSerializerOptions
                 ),
                 GenerativeConfig.Cohere.TypeValue =>
                     JsonSerializer.Deserialize<GenerativeConfig.Cohere>(
-                        vic.GetRawText(),
+                        text,
                         Rest.WeaviateRestClient.RestJsonSerializerOptions
                     ),
                 GenerativeConfig.Databricks.TypeValue =>
                     JsonSerializer.Deserialize<GenerativeConfig.Databricks>(
-                        vic.GetRawText(),
+                        text,
                         Rest.WeaviateRestClient.RestJsonSerializerOptions
                     ),
                 GenerativeConfig.FriendliAI.TypeValue =>
                     JsonSerializer.Deserialize<GenerativeConfig.FriendliAI>(
-                        vic.GetRawText(),
+                        text,
                         Rest.WeaviateRestClient.RestJsonSerializerOptions
                     ),
                 GenerativeConfig.Mistral.TypeValue =>
                     JsonSerializer.Deserialize<GenerativeConfig.Mistral>(
-                        vic.GetRawText(),
+                        text,
                         Rest.WeaviateRestClient.RestJsonSerializerOptions
                     ),
                 GenerativeConfig.OpenAI.TypeValue =>
                     JsonSerializer.Deserialize<GenerativeConfig.OpenAI>(
-                        vic.GetRawText(),
+                        text,
                         Rest.WeaviateRestClient.RestJsonSerializerOptions
                     ),
                 GenerativeConfig.AzureOpenAI.TypeValue =>
                     JsonSerializer.Deserialize<GenerativeConfig.AzureOpenAI>(
-                        vic.GetRawText(),
+                        text,
                         Rest.WeaviateRestClient.RestJsonSerializerOptions
                     ),
                 GenerativeConfig.GoogleGemini.TypeValue =>
                     JsonSerializer.Deserialize<GenerativeConfig.GoogleGemini>(
-                        vic.GetRawText(),
+                        text,
                         Rest.WeaviateRestClient.RestJsonSerializerOptions
                     ),
                 GenerativeConfig.GoogleVertex.TypeValue =>
                     JsonSerializer.Deserialize<GenerativeConfig.GoogleVertex>(
-                        vic.GetRawText(),
+                        text,
                         Rest.WeaviateRestClient.RestJsonSerializerOptions
                     ),
                 GenerativeConfig.XAI.TypeValue => JsonSerializer.Deserialize<GenerativeConfig.XAI>(
-                    vic.GetRawText(),
+                    text,
                     Rest.WeaviateRestClient.RestJsonSerializerOptions
                 ),
                 GenerativeConfig.Nvidia.TypeValue =>
                     JsonSerializer.Deserialize<GenerativeConfig.Nvidia>(
-                        vic.GetRawText(),
+                        text,
                         Rest.WeaviateRestClient.RestJsonSerializerOptions
                     ),
                 GenerativeConfig.Ollama.TypeValue =>
                     JsonSerializer.Deserialize<GenerativeConfig.Ollama>(
-                        vic.GetRawText(),
+                        text,
                         Rest.WeaviateRestClient.RestJsonSerializerOptions
                     ),
                 _ => new GenerativeConfig.Custom
                 {
                     Type = type,
-                    Config = ObjectHelper.ConvertJsonElement(
-                        (
-                            (dynamic?)
-                                JsonSerializer.Deserialize<System.Dynamic.ExpandoObject>(
-                                    vic.GetRawText(),
+                    Config =
+                        ObjectHelper.ConvertJsonElement(
+                            (
+                                JsonSerializer.Deserialize<JsonElement>(
+                                    text,
                                     Rest.WeaviateRestClient.RestJsonSerializerOptions
                                 )
-                        )?.config
-                    ),
+                            ).TryGetProperty("config", out var configElement)
+                                ? configElement
+                                : null
+                        ) ?? new { },
                 },
             };
 

--- a/src/Weaviate.Client/Models/Serialization.RerankerConfig.cs
+++ b/src/Weaviate.Client/Models/Serialization.RerankerConfig.cs
@@ -10,45 +10,49 @@ internal static class RerankerConfigSerialization
 
         if (config is JsonElement vic)
         {
+            var text = vic.GetRawText();
+
             var result = type switch
             {
                 Reranker.Transformers.TypeValue => (IRerankerConfig?)
                     JsonSerializer.Deserialize<Reranker.Transformers>(
-                        vic.GetRawText(),
+                        text,
                         Rest.WeaviateRestClient.RestJsonSerializerOptions
                     ),
                 Reranker.Cohere.TypeValue => JsonSerializer.Deserialize<Reranker.Cohere>(
-                    vic.GetRawText(),
+                    text,
                     Rest.WeaviateRestClient.RestJsonSerializerOptions
                 ),
                 Reranker.VoyageAI.TypeValue => JsonSerializer.Deserialize<Reranker.VoyageAI>(
-                    vic.GetRawText(),
+                    text,
                     Rest.WeaviateRestClient.RestJsonSerializerOptions
                 ),
                 Reranker.JinaAI.TypeValue => JsonSerializer.Deserialize<Reranker.JinaAI>(
-                    vic.GetRawText(),
+                    text,
                     Rest.WeaviateRestClient.RestJsonSerializerOptions
                 ),
                 Reranker.Nvidia.TypeValue => JsonSerializer.Deserialize<Reranker.Nvidia>(
-                    vic.GetRawText(),
+                    text,
                     Rest.WeaviateRestClient.RestJsonSerializerOptions
                 ),
                 Reranker.None.TypeValue => JsonSerializer.Deserialize<Reranker.None>(
-                    vic.GetRawText(),
+                    text,
                     Rest.WeaviateRestClient.RestJsonSerializerOptions
                 ),
                 _ => new Reranker.Custom
                 {
                     Type = type,
-                    Config = ObjectHelper.ConvertJsonElement(
-                        (
-                            (dynamic?)
-                                JsonSerializer.Deserialize<System.Dynamic.ExpandoObject>(
-                                    vic.GetRawText(),
+                    Config =
+                        ObjectHelper.ConvertJsonElement(
+                            (
+                                JsonSerializer.Deserialize<JsonElement>(
+                                    text,
                                     Rest.WeaviateRestClient.RestJsonSerializerOptions
                                 )
-                        )?.config
-                    ),
+                            ).TryGetProperty("config", out var configElement)
+                                ? configElement
+                                : null
+                        ) ?? new { },
                 },
             };
 


### PR DESCRIPTION
Ensure proper serialization of custom configurations for generative and reranker models by updating the handling of configuration objects to default to an empty object when no configuration is provided. This change improves the robustness of the serialization process.