### PR TITLE
Generative NearVector overloads

### DIFF
--- a/src/Weaviate.Client/GenerateClient.NearVector.cs
+++ b/src/Weaviate.Client/GenerateClient.NearVector.cs
@@ -136,4 +136,137 @@ public partial class GenerateClient
         );
         return result;
     }
+
+    /// <summary>
+    /// Search near vector with generative AI capabilities.
+    /// </summary>
+    /// <param name="vector">Vector to search near</param>
+    /// <param name="filters">Filters to apply</param>
+    /// <param name="certainty">Certainty threshold</param>
+    /// <param name="distance">Distance threshold</param>
+    /// <param name="autoLimit">Auto-cut threshold</param>
+    /// <param name="limit">Maximum number of results</param>
+    /// <param name="offset">Offset for pagination</param>
+    /// <param name="targetVector">Target vector name</param>
+    /// <param name="rerank">Rerank configuration</param>
+    /// <param name="singlePrompt">Single prompt for generation</param>
+    /// <param name="groupedTask">Grouped prompt for generation</param>
+    /// <param name="provider">Optional generative provider to enrich prompts that don't have a provider set. If the prompt already has a provider, it will not be overridden.</param>
+    /// <param name="returnProperties">Properties to return</param>
+    /// <param name="returnReferences">References to return</param>
+    /// <param name="returnMetadata">Metadata to return</param>
+    /// <param name="includeVectors">Vectors to include</param>
+    /// <param name="cancellationToken">Cancellation token for the operation</param>
+    /// <returns>Generative result</returns>
+    public async Task<GenerativeWeaviateResult> NearVector(
+        Vectors vector,
+        Filter? filters = null,
+        float? certainty = null,
+        float? distance = null,
+        uint? autoLimit = null,
+        uint? limit = null,
+        uint? offset = null,
+        TargetVectors? targetVector = null,
+        Rerank? rerank = null,
+        SinglePrompt? singlePrompt = null,
+        GroupedTask? groupedTask = null,
+        GenerativeProvider? provider = null,
+        AutoArray<string>? returnProperties = null,
+        IList<QueryReference>? returnReferences = null,
+        MetadataQuery? returnMetadata = null,
+        VectorQuery? includeVectors = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var result = await _client.GrpcClient.SearchNearVector(
+            _collectionClient.Name,
+            (NearVectorInput)vector,
+            distance: distance,
+            certainty: certainty,
+            offset: offset,
+            autoLimit: autoLimit,
+            limit: limit,
+            targetVector: targetVector,
+            filters: filters,
+            tenant: _collectionClient.Tenant,
+            rerank: rerank,
+            singlePrompt: EnrichPrompt(singlePrompt, provider) as SinglePrompt,
+            groupedTask: EnrichPrompt(groupedTask, provider) as GroupedTask,
+            consistencyLevel: _collectionClient.ConsistencyLevel,
+            returnProperties: returnProperties,
+            returnReferences: returnReferences,
+            returnMetadata: returnMetadata,
+            includeVectors: includeVectors,
+            cancellationToken: CreateTimeoutCancellationToken(cancellationToken)
+        );
+        return result;
+    }
+
+    /// <summary>
+    /// Search near vector with generative AI capabilities and grouping.
+    /// </summary>
+    /// <param name="vector">Vector to search near</param>
+    /// <param name="groupBy">Group by configuration</param>
+    /// <param name="filters">Filters to apply</param>
+    /// <param name="distance">Distance threshold</param>
+    /// <param name="certainty">Certainty threshold</param>
+    /// <param name="autoLimit">Auto-cut threshold</param>
+    /// <param name="limit">Maximum number of results</param>
+    /// <param name="offset">Offset for pagination</param>
+    /// <param name="targetVector">Target vector name</param>
+    /// <param name="rerank">Rerank configuration</param>
+    /// <param name="singlePrompt">Single prompt for generation</param>
+    /// <param name="groupedTask">Grouped prompt for generation</param>
+    /// <param name="provider">Optional generative provider to enrich prompts that don't have a provider set. If the prompt already has a provider, it will not be overridden.</param>
+    /// <param name="returnProperties">Properties to return</param>
+    /// <param name="returnReferences">References to return</param>
+    /// <param name="returnMetadata">Metadata to return</param>
+    /// <param name="includeVectors">Vectors to include</param>
+    /// <param name="cancellationToken">Cancellation token for the operation</param>
+    /// <returns>Generative group-by result</returns>
+    public async Task<GenerativeGroupByResult> NearVector(
+        Vectors vector,
+        GroupByRequest groupBy,
+        Filter? filters = null,
+        float? distance = null,
+        float? certainty = null,
+        uint? autoLimit = null,
+        uint? limit = null,
+        uint? offset = null,
+        TargetVectors? targetVector = null,
+        Rerank? rerank = null,
+        SinglePrompt? singlePrompt = null,
+        GroupedTask? groupedTask = null,
+        GenerativeProvider? provider = null,
+        AutoArray<string>? returnProperties = null,
+        IList<QueryReference>? returnReferences = null,
+        MetadataQuery? returnMetadata = null,
+        VectorQuery? includeVectors = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var result = await _client.GrpcClient.SearchNearVector(
+            _collectionClient.Name,
+            (NearVectorInput)vector,
+            groupBy,
+            filters: filters,
+            distance: distance,
+            certainty: certainty,
+            offset: offset,
+            autoLimit: autoLimit,
+            limit: limit,
+            targetVector: targetVector,
+            tenant: _collectionClient.Tenant,
+            rerank: rerank,
+            singlePrompt: EnrichPrompt(singlePrompt, provider) as SinglePrompt,
+            groupedTask: EnrichPrompt(groupedTask, provider) as GroupedTask,
+            consistencyLevel: _collectionClient.ConsistencyLevel,
+            returnProperties: returnProperties,
+            returnReferences: returnReferences,
+            returnMetadata: returnMetadata,
+            includeVectors: includeVectors,
+            cancellationToken: CreateTimeoutCancellationToken(cancellationToken)
+        );
+        return result;
+    }
 }


### PR DESCRIPTION
Generative NearVector overloads for using `float[]` directly without `NearVectorInput`.