### PR TITLE
Rename 'text' parameter to 'query' in NearText methods

### DIFF
--- a/docs/VECTOR_API_OVERVIEW.md
+++ b/docs/VECTOR_API_OVERVIEW.md
@@ -147,13 +147,13 @@ Text-based semantic search with server-side vectorization.
 ```csharp
 // Simple text search
 Task<WeaviateResult> NearText(
-    AutoArray<string> text,
+    AutoArray<string> query,
     ...
 )
 
 // With GroupBy
 Task<GroupByResult> NearText(
-    AutoArray<string> text,
+    AutoArray<string> query,
     GroupByRequest groupBy,
     ...
 )

--- a/src/Weaviate.Client.Tests/Integration/TestSearchHybrid.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestSearchHybrid.cs
@@ -272,7 +272,7 @@ public partial class SearchTests : IntegrationTests
         ).Objects;
         var textRes = (
             await collection.Query.NearText(
-                text: "fruit",
+                query: "fruit",
                 cancellationToken: TestContext.Current.CancellationToken
             )
         ).Objects;

--- a/src/Weaviate.Client/QueryClient.NearText.cs
+++ b/src/Weaviate.Client/QueryClient.NearText.cs
@@ -9,7 +9,7 @@ namespace Weaviate.Client;
 public partial class QueryClient
 {
     /// <summary>Performs a near-text search using the specified parameters.</summary>
-    /// <param name="text">The search text.</param>
+    /// <param name="query">The search text.</param>
     /// <param name="certainty">Certainty threshold for the search.</param>
     /// <param name="distance">Distance threshold for the search.</param>
     /// <param name="moveTo">Move-to configuration.</param>
@@ -26,7 +26,7 @@ public partial class QueryClient
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Search results.</returns>
     public async Task<WeaviateResult> NearText(
-        AutoArray<string> text,
+        AutoArray<string> query,
         float? certainty = null,
         float? distance = null,
         Move? moveTo = null,
@@ -44,7 +44,7 @@ public partial class QueryClient
     ) =>
         await _grpc.SearchNearText(
             _collectionClient.Name,
-            text.ToArray(),
+            [.. query],
             distance: distance,
             certainty: certainty,
             limit: limit,
@@ -65,7 +65,7 @@ public partial class QueryClient
         );
 
     /// <summary>Performs a near-text search with group-by using the specified parameters.</summary>
-    /// <param name="text">The search text.</param>
+    /// <param name="query">The search text.</param>
     /// <param name="groupBy">Group-by configuration.</param>
     /// <param name="certainty">Certainty threshold for the search.</param>
     /// <param name="distance">Distance threshold for the search.</param>
@@ -83,7 +83,7 @@ public partial class QueryClient
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Grouped search results.</returns>
     public async Task<GroupByResult> NearText(
-        AutoArray<string> text,
+        AutoArray<string> query,
         GroupByRequest groupBy,
         float? certainty = null,
         float? distance = null,
@@ -102,7 +102,7 @@ public partial class QueryClient
     ) =>
         await _grpc.SearchNearText(
             _collectionClient.Name,
-            text.ToArray(),
+            [.. query],
             groupBy: groupBy,
             distance: distance,
             certainty: certainty,
@@ -164,7 +164,7 @@ public partial class QueryClient
         var input = query(VectorInputBuilderFactories.CreateNearTextBuilder());
         return await _grpc.SearchNearText(
             _collectionClient.Name,
-            input.Query.ToArray(),
+            [.. input.Query],
             distance: input.Distance,
             certainty: input.Certainty,
             limit: limit,
@@ -220,7 +220,7 @@ public partial class QueryClient
         var input = query(VectorInputBuilderFactories.CreateNearTextBuilder());
         return await _grpc.SearchNearText(
             _collectionClient.Name,
-            input.Query.ToArray(),
+            [.. input.Query],
             groupBy: groupBy,
             distance: input.Distance,
             certainty: input.Certainty,
@@ -286,7 +286,7 @@ public static class QueryClientNearTextExtensions
 
         // Otherwise use the base method
         return await client.NearText(
-            text: input.Query,
+            query: input.Query,
             certainty: input.Certainty,
             distance: input.Distance,
             moveTo: input.MoveTo,
@@ -344,7 +344,7 @@ public static class QueryClientNearTextExtensions
 
         // Otherwise use the base method
         return await client.NearText(
-            text: input.Query,
+            query: input.Query,
             groupBy: groupBy,
             certainty: input.Certainty,
             distance: input.Distance,

--- a/src/Weaviate.Client/Typed/TypedQueryClient.NearText.cs
+++ b/src/Weaviate.Client/Typed/TypedQueryClient.NearText.cs
@@ -12,7 +12,7 @@ public partial class TypedQueryClient<T>
     /// <summary>
     /// Performs a near-text search using text embeddings.
     /// </summary>
-    /// <param name="text">The text to search for (single or multiple strings).</param>
+    /// <param name="query">The text to search for (single or multiple strings).</param>
     /// <param name="certainty">Minimum certainty threshold (0-1).</param>
     /// <param name="distance">Maximum distance threshold.</param>
     /// <param name="moveTo">Move the query vector towards these concepts.</param>
@@ -28,8 +28,8 @@ public partial class TypedQueryClient<T>
     /// <param name="includeVectors">Vector configuration for returned objects.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A strongly-typed result containing the search results.</returns>
-    public async Task<WeaviateResult<WeaviateObject<T>>> NearText(
-        AutoArray<string> text,
+    public async Task<Models.WeaviateResult<WeaviateObject<T>>> NearText(
+        AutoArray<string> query,
         float? certainty = null,
         float? distance = null,
         Move? moveTo = null,
@@ -47,7 +47,7 @@ public partial class TypedQueryClient<T>
     )
     {
         var result = await _queryClient.NearText(
-            text: text,
+            query: query,
             certainty: certainty,
             distance: distance,
             moveTo: moveTo,
@@ -69,7 +69,7 @@ public partial class TypedQueryClient<T>
     /// <summary>
     /// Performs a near-text search with group-by aggregation.
     /// </summary>
-    /// <param name="text">The text to search for (single or multiple strings).</param>
+    /// <param name="query">The text to search for (single or multiple strings).</param>
     /// <param name="groupBy">Group-by configuration.</param>
     /// <param name="certainty">Minimum certainty threshold (0-1).</param>
     /// <param name="distance">Maximum distance threshold.</param>
@@ -87,7 +87,7 @@ public partial class TypedQueryClient<T>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A strongly-typed grouped result.</returns>
     public async Task<GroupByResult<T>> NearText(
-        AutoArray<string> text,
+        AutoArray<string> query,
         GroupByRequest groupBy,
         float? certainty = null,
         float? distance = null,
@@ -106,7 +106,7 @@ public partial class TypedQueryClient<T>
     )
     {
         var result = await _queryClient.NearText(
-            text: text,
+            query: query,
             groupBy: groupBy,
             certainty: certainty,
             distance: distance,


### PR DESCRIPTION
Standardize the parameter name from 'text' to 'query' across all NearText methods for consistency and clarity. This change improves code readability and aligns with naming conventions.