### PR TITLE
Support new backup restore statuses

### DIFF
--- a/src/Weaviate.Client.Tests/Integration/TestBackups.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestBackups.cs
@@ -62,6 +62,8 @@ public class TestBackups : IntegrationTests
                         is BackupStatus.Started
                             or BackupStatus.Transferring
                             or BackupStatus.Transferred
+                            or BackupStatus.Cancelling
+                            or BackupStatus.Finalizing
                     )
                     {
                         try
@@ -84,6 +86,8 @@ public class TestBackups : IntegrationTests
                         is BackupStatus.Started
                             or BackupStatus.Transferring
                             or BackupStatus.Transferred
+                            or BackupStatus.Cancelling
+                            or BackupStatus.Finalizing
                 )
                 .ToList();
 

--- a/src/Weaviate.Client/Models/Backup.cs
+++ b/src/Weaviate.Client/Models/Backup.cs
@@ -41,6 +41,16 @@ public enum BackupStatus
     /// The canceled backup status
     /// </summary>
     Canceled,
+
+    /// <summary>
+    /// The cancelling backup status - cancellation has been claimed by a coordinator
+    /// </summary>
+    Cancelling,
+
+    /// <summary>
+    /// The finalizing backup status - file staging is complete and schema changes are being applied
+    /// </summary>
+    Finalizing,
 }
 
 /// <summary>
@@ -263,6 +273,8 @@ public static class BackupStatusExtensions
             "SUCCESS" => BackupStatus.Success,
             "FAILED" => BackupStatus.Failed,
             "CANCELED" => BackupStatus.Canceled,
+            "CANCELLING" => BackupStatus.Cancelling,
+            "FINALIZING" => BackupStatus.Finalizing,
             _ => BackupStatus.Unknown,
         };
     }

--- a/src/Weaviate.Client/Rest/Dto/Models.g.cs
+++ b/src/Weaviate.Client/Rest/Dto/Models.g.cs
@@ -4415,6 +4415,12 @@ namespace Weaviate.Client.Rest.Dto
         [System.Runtime.Serialization.EnumMember(Value = @"CANCELED")]
         CANCELED = 5,
 
+        [System.Runtime.Serialization.EnumMember(Value = @"CANCELLING")]
+        CANCELLING = 6,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"FINALIZING")]
+        FINALIZING = 7,
+
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -4513,6 +4519,12 @@ namespace Weaviate.Client.Rest.Dto
 
         [System.Runtime.Serialization.EnumMember(Value = @"CANCELED")]
         CANCELED = 5,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"CANCELLING")]
+        CANCELLING = 6,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"FINALIZING")]
+        FINALIZING = 7,
 
     }
 


### PR DESCRIPTION
In support of server PR [#10135](https://github.com/weaviate/weaviate/pull/10135), this introduces two new restore status values: `CANCELLING` and `FINALIZING`