### PR TITLE
chore: sync proto and OpenAPI specs from Weaviate v1.36

### DIFF
--- a/src/Weaviate.Client.Tests/Unit/PermissionsScopeTests.cs
+++ b/src/Weaviate.Client.Tests/Unit/PermissionsScopeTests.cs
@@ -425,6 +425,7 @@ public class PermissionsScopeTests
             "Delete_aliases",
             "Assign_and_revoke_groups",
             "Read_groups",
+            "Manage_mcp",
         };
         foreach (var action in allActions)
         {

--- a/src/Weaviate.Client/Rest/Dto/Models.g.cs
+++ b/src/Weaviate.Client/Rest/Dto/Models.g.cs
@@ -285,6 +285,14 @@ namespace Weaviate.Client.Rest.Dto
         public Aliases? Aliases { get; set; } = default!;
 
         /// <summary>
+        /// resources applicable for MCP actions
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("mcp")]
+
+        public System.Collections.Generic.IDictionary<string, object>? Mcp { get; set; } = default!;
+
+        /// <summary>
         /// Allowed actions in weaviate.
         /// </summary>
 
@@ -673,6 +681,14 @@ namespace Weaviate.Client.Rest.Dto
         public System.DateTimeOffset? StartedAt { get; set; } = default!;
 
         /// <summary>
+        /// When the export completed (successfully, with failure, or was canceled)
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("completedAt")]
+
+        public System.DateTimeOffset? CompletedAt { get; set; } = default!;
+
+        /// <summary>
         /// Duration of the export in milliseconds
         /// </summary>
 
@@ -1006,6 +1022,114 @@ namespace Weaviate.Client.Rest.Dto
     }
 
     /// <summary>
+    /// Request body for the generic tokenize endpoint.
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.1.0 (NJsonSchema v11.5.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    internal partial record TokenizeRequest
+    {
+        /// <summary>
+        /// The text to tokenize.
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("text")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+
+        public string Text { get; set; } = default!;
+
+        /// <summary>
+        /// The tokenization method to apply.
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("tokenization")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
+
+        public TokenizeRequestTokenization Tokenization { get; set; } = default!;
+
+        /// <summary>
+        /// Optional text analyzer configuration (e.g. ASCII folding).
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("analyzerConfig")]
+
+        public TextAnalyzerConfig? AnalyzerConfig { get; set; } = default!;
+
+        /// <summary>
+        /// Optional stopword configuration. When provided, stopwords are removed from query tokens but preserved in indexed tokens.
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("stopwordConfig")]
+
+        public StopwordConfig? StopwordConfig { get; set; } = default!;
+
+    }
+
+    /// <summary>
+    /// Response from the tokenize endpoint.
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.1.0 (NJsonSchema v11.5.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    internal partial record TokenizeResponse
+    {
+        /// <summary>
+        /// The tokenization method that was applied.
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("tokenization")]
+
+        public string? Tokenization { get; set; } = default!;
+
+        /// <summary>
+        /// The text analyzer configuration that was used, if any.
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("analyzerConfig")]
+
+        public TextAnalyzerConfig? AnalyzerConfig { get; set; } = default!;
+
+        /// <summary>
+        /// The stopword configuration that was used, if any.
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("stopwordConfig")]
+
+        public StopwordConfig? StopwordConfig { get; set; } = default!;
+
+        /// <summary>
+        /// The tokens as they would be stored in the inverted index.
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("indexed")]
+
+        public System.Collections.Generic.IList<string>? Indexed { get; set; } = default!;
+
+        /// <summary>
+        /// The tokens as they would be used for query matching (e.g., after stopword removal).
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("query")]
+
+        public System.Collections.Generic.IList<string>? Query { get; set; } = default!;
+
+    }
+
+    /// <summary>
+    /// Request body for the property-specific tokenize endpoint.
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.1.0 (NJsonSchema v11.5.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    internal partial record PropertyTokenizeRequest
+    {
+        /// <summary>
+        /// The text to tokenize using the property's configured tokenization.
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("text")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+
+        public string Text { get; set; } = default!;
+
+    }
+
+    /// <summary>
     /// Configuration related to multi-tenancy within a collection (class)
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.1.0 (NJsonSchema v11.5.1.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -1114,100 +1238,6 @@ namespace Weaviate.Client.Rest.Dto
         [System.Text.Json.Serialization.JsonPropertyName("grpcMaxMessageSize")]
 
         public int? GrpcMaxMessageSize { get; set; } = default!;
-
-    }
-
-    /// <summary>
-    /// Either a JSONPatch document as defined by RFC 6902 (from, op, path, value), or a merge document (RFC 7396).
-    /// </summary>
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.1.0 (NJsonSchema v11.5.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    internal partial record PatchDocumentObject
-    {
-        /// <summary>
-        /// A string containing a JSON Pointer value.
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("from")]
-
-        public string? From { get; set; } = default!;
-
-        /// <summary>
-        /// The operation to be performed.
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("op")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
-
-        public PatchDocumentObjectOp Op { get; set; } = default!;
-
-        /// <summary>
-        /// A JSON-Pointer.
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("path")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-
-        public string Path { get; set; } = default!;
-
-        /// <summary>
-        /// The value to be used within the operations.
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("value")]
-
-        public System.Collections.Generic.IDictionary<string, object>? Value { get; set; } = default!;
-
-        [System.Text.Json.Serialization.JsonPropertyName("merge")]
-
-        public Object? Merge { get; set; } = default!;
-
-    }
-
-    /// <summary>
-    /// Either a JSONPatch document as defined by RFC 6902 (from, op, path, value), or a merge document (RFC 7396).
-    /// </summary>
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.1.0 (NJsonSchema v11.5.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    internal partial record PatchDocumentAction
-    {
-        /// <summary>
-        /// A string containing a JSON Pointer value.
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("from")]
-
-        public string? From { get; set; } = default!;
-
-        /// <summary>
-        /// The operation to be performed.
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("op")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
-
-        public PatchDocumentActionOp Op { get; set; } = default!;
-
-        /// <summary>
-        /// A JSON-Pointer.
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("path")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-
-        public string Path { get; set; } = default!;
-
-        /// <summary>
-        /// The value to be used within the operations.
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("value")]
-
-        public System.Collections.Generic.IDictionary<string, object>? Value { get; set; } = default!;
-
-        [System.Text.Json.Serialization.JsonPropertyName("merge")]
-
-        public Object? Merge { get; set; } = default!;
 
     }
 
@@ -1361,76 +1391,6 @@ namespace Weaviate.Client.Rest.Dto
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
 
         public string Collection { get; set; } = default!;
-
-    }
-
-    /// <summary>
-    /// Specifies the parameters required to mark a specific shard replica as inactive (soft-delete) on a particular node. This action typically prevents the replica from serving requests but does not immediately remove its data.
-    /// </summary>
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.1.0 (NJsonSchema v11.5.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    internal partial record ReplicationDisableReplicaRequest
-    {
-        /// <summary>
-        /// The name of the Weaviate node hosting the shard replica that is to be disabled.
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("node")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-
-        public string Node { get; set; } = default!;
-
-        /// <summary>
-        /// The name of the collection to which the shard replica belongs.
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("collection")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-
-        public string Collection { get; set; } = default!;
-
-        /// <summary>
-        /// The ID of the shard whose replica is to be disabled.
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("shard")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-
-        public string Shard { get; set; } = default!;
-
-    }
-
-    /// <summary>
-    /// Specifies the parameters required to permanently delete a specific shard replica from a particular node. This action will remove the replica's data from the node.
-    /// </summary>
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.1.0 (NJsonSchema v11.5.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    internal partial record ReplicationDeleteReplicaRequest
-    {
-        /// <summary>
-        /// The name of the Weaviate node from which the shard replica will be deleted.
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("node")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-
-        public string Node { get; set; } = default!;
-
-        /// <summary>
-        /// The name of the collection to which the shard replica belongs.
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("collection")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-
-        public string Collection { get; set; } = default!;
-
-        /// <summary>
-        /// The ID of the shard whose replica is to be deleted.
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("shard")]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-
-        public string Shard { get; set; } = default!;
 
     }
 
@@ -1788,54 +1748,6 @@ namespace Weaviate.Client.Rest.Dto
 
     }
 
-    /// <summary>
-    /// Indicates the health of the schema in a cluster.
-    /// </summary>
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.1.0 (NJsonSchema v11.5.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    internal partial record SchemaClusterStatus
-    {
-        /// <summary>
-        /// True if the cluster is in sync, false if there is an issue (see error).
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("healthy")]
-
-        public bool? Healthy { get; set; } = default!;
-
-        /// <summary>
-        /// Contains the sync check error if one occurred
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("error")]
-
-        public string? Error { get; set; } = default!;
-
-        /// <summary>
-        /// Hostname of the coordinating node, i.e. the one that received the cluster. This can be useful information if the error message contains phrases such as 'other nodes agree, but local does not', etc.
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("hostname")]
-
-        public string? Hostname { get; set; } = default!;
-
-        /// <summary>
-        /// Number of nodes that participated in the sync check
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("nodeCount")]
-
-        public double? NodeCount { get; set; } = default!;
-
-        /// <summary>
-        /// The cluster check at startup can be ignored (to recover from an out-of-sync situation).
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("ignoreSchemaSync")]
-
-        public bool? IgnoreSchemaSync { get; set; } = default!;
-
-    }
-
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.1.0 (NJsonSchema v11.5.1.0 (Newtonsoft.Json v13.0.0.0))")]
     internal partial record Class
     {
@@ -2021,6 +1933,34 @@ namespace Weaviate.Client.Rest.Dto
 
         public bool? DisableDuplicatedReferences { get; set; } = true;
 
+        [System.Text.Json.Serialization.JsonPropertyName("textAnalyzer")]
+
+        public TextAnalyzerConfig? TextAnalyzer { get; set; } = default!;
+
+    }
+
+    /// <summary>
+    /// Text analysis options for a property. The asciiFold setting is immutable after creation, while the asciiFoldIgnore list can be updated later; changes to asciiFoldIgnore only affect newly indexed data and do not retroactively re-index existing data. Applies only to text and text[] data types that use an inverted index (searchable or filterable).
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.1.0 (NJsonSchema v11.5.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    internal partial record TextAnalyzerConfig
+    {
+        /// <summary>
+        /// If true, accent/diacritic marks are folded to their base characters during indexing and search. For example, 'école' matches 'ecole'. Defaults to false.
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("asciiFold")]
+
+        public bool? AsciiFold { get; set; } = default!;
+
+        /// <summary>
+        /// If provided, specifies a list of characters that should be excluded from ascii folding. For example, if ['é'] is provided, then 'é' will not be folded to 'e' during indexing and search. This list can be updated after the property is created, but updates only affect documents indexed after the change.
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("asciiFoldIgnore")]
+
+        public System.Collections.Generic.IList<string>? AsciiFoldIgnore { get; set; } = default!;
+
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.1.0 (NJsonSchema v11.5.1.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -2092,6 +2032,10 @@ namespace Weaviate.Client.Rest.Dto
         [System.Text.Json.Serialization.JsonPropertyName("nestedProperties")]
 
         public System.Collections.Generic.IList<NestedProperty>? NestedProperties { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("textAnalyzer")]
+
+        public TextAnalyzerConfig? TextAnalyzer { get; set; } = default!;
 
     }
 
@@ -3045,6 +2989,78 @@ namespace Weaviate.Client.Rest.Dto
         [System.Text.Json.Serialization.JsonPropertyName("payload")]
 
         public System.Collections.Generic.IDictionary<string, object>? Payload { get; set; } = default!;
+
+        /// <summary>
+        /// Units of the task. Only present for tasks that use unit tracking.
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("units")]
+
+        public System.Collections.Generic.IList<DistributedTaskUnit>? Units { get; set; } = default!;
+
+    }
+
+    /// <summary>
+    /// A unit of a distributed task.
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.1.0 (NJsonSchema v11.5.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    internal partial record DistributedTaskUnit
+    {
+        /// <summary>
+        /// The ID of the unit.
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("id")]
+
+        public string? Id { get; set; } = default!;
+
+        /// <summary>
+        /// The node that owns this unit.
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("nodeId")]
+
+        public string? NodeId { get; set; } = default!;
+
+        /// <summary>
+        /// The status of the unit.
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("status")]
+
+        public string? Status { get; set; } = default!;
+
+        /// <summary>
+        /// The progress of the unit (0.0 to 1.0).
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("progress")]
+
+        public float? Progress { get; set; } = default!;
+
+        /// <summary>
+        /// The error message if the unit failed.
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("error")]
+
+        public string? Error { get; set; } = default!;
+
+        /// <summary>
+        /// The time when the unit was last updated.
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("updatedAt")]
+
+        public System.DateTimeOffset? UpdatedAt { get; set; } = default!;
+
+        /// <summary>
+        /// The time when the unit finished.
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("finishedAt")]
+
+        public System.DateTimeOffset? FinishedAt { get; set; } = default!;
 
     }
 
@@ -4713,6 +4729,9 @@ namespace Weaviate.Client.Rest.Dto
         [System.Text.Json.Serialization.JsonStringEnumMemberName(@"read_groups")]
         Read_groups = 33,
 
+        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"manage_mcp")]
+        Manage_mcp = 34,
+
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.1.0 (NJsonSchema v11.5.1.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -4778,14 +4797,6 @@ namespace Weaviate.Client.Rest.Dto
     internal partial record Config
     {
         /// <summary>
-        /// Bucket, container, or volume name for cloud storage backends
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("bucket")]
-
-        public string? Bucket { get; set; } = default!;
-
-        /// <summary>
         /// Path prefix within the bucket or filesystem
         /// </summary>
 
@@ -4823,32 +4834,23 @@ namespace Weaviate.Client.Rest.Dto
         [System.Text.Json.Serialization.JsonStringEnumMemberName(@"CANCELED")]
         CANCELED = 4,
 
-        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"SKIPPED")]
-        SKIPPED = 5,
-
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.1.0 (NJsonSchema v11.5.1.0 (Newtonsoft.Json v13.0.0.0))")]
     internal enum ShardProgressStatus
     {
 
-        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"STARTED")]
-        STARTED = 0,
-
         [System.Text.Json.Serialization.JsonStringEnumMemberName(@"TRANSFERRING")]
-        TRANSFERRING = 1,
+        TRANSFERRING = 0,
 
         [System.Text.Json.Serialization.JsonStringEnumMemberName(@"SUCCESS")]
-        SUCCESS = 2,
+        SUCCESS = 1,
 
         [System.Text.Json.Serialization.JsonStringEnumMemberName(@"FAILED")]
-        FAILED = 3,
-
-        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"CANCELED")]
-        CANCELED = 4,
+        FAILED = 2,
 
         [System.Text.Json.Serialization.JsonStringEnumMemberName(@"SKIPPED")]
-        SKIPPED = 5,
+        SKIPPED = 3,
 
     }
 
@@ -4905,50 +4907,35 @@ namespace Weaviate.Client.Rest.Dto
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.1.0 (NJsonSchema v11.5.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    internal enum PatchDocumentObjectOp
+    internal enum TokenizeRequestTokenization
     {
 
-        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"add")]
-        Add = 0,
+        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"word")]
+        Word = 0,
 
-        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"remove")]
-        Remove = 1,
+        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"lowercase")]
+        Lowercase = 1,
 
-        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"replace")]
-        Replace = 2,
+        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"whitespace")]
+        Whitespace = 2,
 
-        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"move")]
-        Move = 3,
+        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"field")]
+        Field = 3,
 
-        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"copy")]
-        Copy = 4,
+        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"trigram")]
+        Trigram = 4,
 
-        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"test")]
-        Test = 5,
+        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"gse")]
+        Gse = 5,
 
-    }
+        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"kagome_kr")]
+        Kagome_kr = 6,
 
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.1.0 (NJsonSchema v11.5.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    internal enum PatchDocumentActionOp
-    {
+        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"kagome_ja")]
+        Kagome_ja = 7,
 
-        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"add")]
-        Add = 0,
-
-        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"remove")]
-        Remove = 1,
-
-        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"replace")]
-        Replace = 2,
-
-        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"move")]
-        Move = 3,
-
-        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"copy")]
-        Copy = 4,
-
-        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"test")]
-        Test = 5,
+        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"gse_ch")]
+        Gse_ch = 8,
 
     }
 
@@ -5739,6 +5726,43 @@ namespace Weaviate.Client.Rest.Dto
         FAILED = 2,
 
     }
+
+    [System.CodeDom.Compiler.GeneratedCode("NSwag", "14.6.1.0 (NJsonSchema v11.5.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class FileResponse : System.IDisposable
+    {
+        private System.IDisposable? _client;
+        private System.IDisposable? _response;
+
+        public int StatusCode { get; private set; }
+
+        public System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> Headers { get; private set; }
+
+        public System.IO.Stream Stream { get; private set; }
+
+        public bool IsPartial
+        {
+            get { return StatusCode == 206; }
+        }
+
+        public FileResponse(int statusCode, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.IO.Stream stream, System.IDisposable? client, System.IDisposable? response)
+        {
+            StatusCode = statusCode;
+            Headers = headers;
+            Stream = stream;
+            _client = client;
+            _response = response;
+        }
+
+        public void Dispose()
+        {
+            Stream.Dispose();
+            if (_response != null)
+                _response.Dispose();
+            if (_client != null)
+                _client.Dispose();
+        }
+    }
+
 
 
 }

--- a/src/Weaviate.Client/Rest/Schema/openapi.json
+++ b/src/Weaviate.Client/Rest/Schema/openapi.json
@@ -307,6 +307,11 @@
             }
           }
         },
+        "mcp": {
+          "type": "object",
+          "description": "resources applicable for MCP actions",
+          "properties": {}
+        },
         "action": {
           "type": "string",
           "description": "Allowed actions in weaviate.",
@@ -344,7 +349,8 @@
             "update_aliases",
             "delete_aliases",
             "assign_and_revoke_groups",
-            "read_groups"
+            "read_groups",
+            "manage_mcp"
           ]
         }
       },
@@ -504,47 +510,6 @@
         "$ref": "#/definitions/Vector"
       }
     },
-    "C11yVectorBasedQuestion": {
-      "description": "Receive question based on array of collection names (classes), properties and values.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "classVectors": {
-            "description": "Vectorized collection (class) name.",
-            "type": "array",
-            "items": {
-              "type": "number",
-              "format": "float"
-            },
-            "minItems": 300,
-            "maxItems": 300
-          },
-          "classProps": {
-            "description": "Vectorized properties.",
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "propsVectors": {
-                  "type": "array",
-                  "items": {
-                    "type": "number",
-                    "format": "float"
-                  }
-                },
-                "value": {
-                  "description": "String with valuename.",
-                  "type": "string"
-                }
-              }
-            },
-            "minItems": 300,
-            "maxItems": 300
-          }
-        }
-      }
-    },
     "Deprecation": {
       "type": "object",
       "properties": {
@@ -650,10 +615,6 @@
           "type": "object",
           "description": "Backend-specific configuration",
           "properties": {
-            "bucket": {
-              "type": "string",
-              "description": "Bucket, container, or volume name for cloud storage backends"
-            },
             "path": {
               "type": "string",
               "description": "Path prefix within the bucket or filesystem"
@@ -716,12 +677,17 @@
         "status": {
           "type": "string",
           "description": "Current status of the export",
-          "enum": ["STARTED", "TRANSFERRING", "SUCCESS", "FAILED", "CANCELED", "SKIPPED"]
+          "enum": ["STARTED", "TRANSFERRING", "SUCCESS", "FAILED", "CANCELED"]
         },
         "startedAt": {
           "type": "string",
           "format": "date-time",
           "description": "When the export started"
+        },
+        "completedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the export completed (successfully, with failure, or was canceled)"
         },
         "tookInMs": {
           "type": "integer",
@@ -758,7 +724,7 @@
         "status": {
           "type": "string",
           "description": "Status of this shard's export",
-          "enum": ["STARTED", "TRANSFERRING", "SUCCESS", "FAILED", "CANCELED", "SKIPPED"]
+          "enum": ["TRANSFERRING", "SUCCESS", "FAILED", "SKIPPED"]
         },
         "objectsExported": {
           "type": "integer",
@@ -998,6 +964,83 @@
         }
       }
     },
+    "TokenizeRequest": {
+      "description": "Request body for the generic tokenize endpoint.",
+      "type": "object",
+      "required": ["text", "tokenization"],
+      "properties": {
+        "text": {
+          "description": "The text to tokenize.",
+          "type": "string"
+        },
+        "tokenization": {
+          "description": "The tokenization method to apply.",
+          "type": "string",
+          "enum": [
+            "word",
+            "lowercase",
+            "whitespace",
+            "field",
+            "trigram",
+            "gse",
+            "kagome_kr",
+            "kagome_ja",
+            "gse_ch"
+          ]
+        },
+        "analyzerConfig": {
+          "description": "Optional text analyzer configuration (e.g. ASCII folding).",
+          "$ref": "#/definitions/TextAnalyzerConfig"
+        },
+        "stopwordConfig": {
+          "description": "Optional stopword configuration. When provided, stopwords are removed from query tokens but preserved in indexed tokens.",
+          "$ref": "#/definitions/StopwordConfig"
+        }
+      }
+    },
+    "TokenizeResponse": {
+      "description": "Response from the tokenize endpoint.",
+      "type": "object",
+      "properties": {
+        "tokenization": {
+          "description": "The tokenization method that was applied.",
+          "type": "string"
+        },
+        "analyzerConfig": {
+          "description": "The text analyzer configuration that was used, if any.",
+          "$ref": "#/definitions/TextAnalyzerConfig"
+        },
+        "stopwordConfig": {
+          "description": "The stopword configuration that was used, if any.",
+          "$ref": "#/definitions/StopwordConfig"
+        },
+        "indexed": {
+          "description": "The tokens as they would be stored in the inverted index.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "query": {
+          "description": "The tokens as they would be used for query matching (e.g., after stopword removal).",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PropertyTokenizeRequest": {
+      "description": "Request body for the property-specific tokenize endpoint.",
+      "type": "object",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "description": "The text to tokenize using the property's configured tokenization.",
+          "type": "string"
+        }
+      }
+    },
     "MultiTenancyConfig": {
       "description": "Configuration related to multi-tenancy within a collection (class)",
       "properties": {
@@ -1018,10 +1061,10 @@
         }
       }
     },
-    "ObjectTtlConfig":{
+    "ObjectTtlConfig": {
       "description": "Configuration of objects' time-to-live",
       "properties": {
-         "enabled": {
+        "enabled": {
           "description": "Whether or not object ttl is enabled for this collection (default: `false`).",
           "type": "boolean",
           "x-omitempty": false
@@ -1076,78 +1119,6 @@
         "$ref": "#/definitions/SingleRef"
       },
       "type": "array"
-    },
-    "PatchDocumentObject": {
-      "description": "Either a JSONPatch document as defined by RFC 6902 (from, op, path, value), or a merge document (RFC 7396).",
-      "properties": {
-        "from": {
-          "description": "A string containing a JSON Pointer value.",
-          "type": "string"
-        },
-        "op": {
-          "description": "The operation to be performed.",
-          "enum": [
-            "add",
-            "remove",
-            "replace",
-            "move",
-            "copy",
-            "test"
-          ],
-          "type": "string"
-        },
-        "path": {
-          "description": "A JSON-Pointer.",
-          "type": "string"
-        },
-        "value": {
-          "description": "The value to be used within the operations.",
-          "type": "object"
-        },
-        "merge": {
-          "$ref": "#/definitions/Object"
-        }
-      },
-      "required": [
-        "op",
-        "path"
-      ]
-    },
-    "PatchDocumentAction": {
-      "description": "Either a JSONPatch document as defined by RFC 6902 (from, op, path, value), or a merge document (RFC 7396).",
-      "properties": {
-        "from": {
-          "description": "A string containing a JSON Pointer value.",
-          "type": "string"
-        },
-        "op": {
-          "description": "The operation to be performed.",
-          "enum": [
-            "add",
-            "remove",
-            "replace",
-            "move",
-            "copy",
-            "test"
-          ],
-          "type": "string"
-        },
-        "path": {
-          "description": "A JSON-Pointer.",
-          "type": "string"
-        },
-        "value": {
-          "description": "The value to be used within the operations.",
-          "type": "object"
-        },
-        "merge": {
-          "$ref": "#/definitions/Object"
-        }
-      },
-      "required": [
-        "op",
-        "path"
-      ]
     },
     "ReplicationReplicateReplicaRequest": {
       "description": "Specifies the parameters required to initiate a shard replica movement operation between two nodes for a given collection and shard. This request defines the source and target node, the collection and type of transfer.",
@@ -1287,52 +1258,6 @@
         "operationIds",
         "planId",
         "collection"
-      ]
-    },
-    "ReplicationDisableReplicaRequest": {
-      "description": "Specifies the parameters required to mark a specific shard replica as inactive (soft-delete) on a particular node. This action typically prevents the replica from serving requests but does not immediately remove its data.",
-      "properties": {
-        "node": {
-          "description": "The name of the Weaviate node hosting the shard replica that is to be disabled.",
-          "type": "string"
-        },
-        "collection": {
-          "description": "The name of the collection to which the shard replica belongs.",
-          "type": "string"
-        },
-        "shard": {
-          "description": "The ID of the shard whose replica is to be disabled.",
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "required": [
-        "node",
-        "collection",
-        "shard"
-      ]
-    },
-    "ReplicationDeleteReplicaRequest": {
-      "description": "Specifies the parameters required to permanently delete a specific shard replica from a particular node. This action will remove the replica's data from the node.",
-      "properties": {
-        "node": {
-          "description": "The name of the Weaviate node from which the shard replica will be deleted.",
-          "type": "string"
-        },
-        "collection": {
-          "description": "The name of the collection to which the shard replica belongs.",
-          "type": "string"
-        },
-        "shard": {
-          "description": "The ID of the shard whose replica is to be deleted.",
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "required": [
-        "node",
-        "collection",
-        "shard"
       ]
     },
     "ReplicationShardReplicas": {
@@ -1553,23 +1478,12 @@
         }
       }
     },
-    "PeerUpdateList": {
-      "description": "List of known peers.",
-      "items": {
-        "$ref": "#/definitions/PeerUpdate"
-      },
-      "type": "array"
-    },
     "VectorWeights": {
       "description": "Allow custom overrides of vector weights as math expressions. E.g. `pancake`: `7` will set the weight for the word pancake to 7 in the vectorization, whereas `w * 3` would triple the originally calculated word. This is an open object, with OpenAPI Specification 3.0 this will be more detailed. See Weaviate docs for more info. In the future this will become a key/value (string/string) object.",
       "type": "object"
     },
     "PropertySchema": {
       "description": "Names and values of an individual property. A returned response may also contain additional metadata, such as from classification or feature projection.",
-      "type": "object"
-    },
-    "SchemaHistory": {
-      "description": "This is an open object, with OpenAPI Specification 3.0 this will be more detailed. See Weaviate docs for more info. In the future this will become a key/value OR a SingleRef definition.",
       "type": "object"
     },
     "Schema": {
@@ -1590,36 +1504,6 @@
         "name": {
           "description": "Name of the schema.",
           "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "SchemaClusterStatus": {
-      "description": "Indicates the health of the schema in a cluster.",
-      "properties": {
-        "healthy": {
-          "description": "True if the cluster is in sync, false if there is an issue (see error).",
-          "type": "boolean",
-          "x-omitempty": false
-        },
-        "error": {
-          "description": "Contains the sync check error if one occurred",
-          "type": "string",
-          "x-omitempty": true
-        },
-        "hostname": {
-          "description": "Hostname of the coordinating node, i.e. the one that received the cluster. This can be useful information if the error message contains phrases such as 'other nodes agree, but local does not', etc.",
-          "type": "string"
-        },
-        "nodeCount": {
-          "description": "Number of nodes that participated in the sync check",
-          "type": "number",
-          "format": "int"
-        },
-        "ignoreSchemaSync": {
-          "description": "The cluster check at startup can be ignored (to recover from an out-of-sync situation).",
-          "type": "boolean",
-          "x-omitempty": false
         }
       },
       "type": "object"
@@ -1752,8 +1636,30 @@
           "type": "boolean",
           "x-nullable": true,
           "default": true
+        },
+        "textAnalyzer": {
+          "$ref": "#/definitions/TextAnalyzerConfig"
         }
       },
+      "type": "object"
+    },
+    "TextAnalyzerConfig": {
+      "description": "Text analysis options for a property. The asciiFold setting is immutable after creation, while the asciiFoldIgnore list can be updated later; changes to asciiFoldIgnore only affect newly indexed data and do not retroactively re-index existing data. Applies only to text and text[] data types that use an inverted index (searchable or filterable).",
+      "properties": {
+        "asciiFold": {
+          "description": "If true, accent/diacritic marks are folded to their base characters during indexing and search. For example, 'école' matches 'ecole'. Defaults to false.",
+          "type": "boolean"
+        },
+        "asciiFoldIgnore": {
+          "description": "If provided, specifies a list of characters that should be excluded from ascii folding. For example, if ['é'] is provided, then 'é' will not be folded to 'e' during indexing and search. This list can be updated after the property is created, but updates only affect documents indexed after the change.",
+          "type": "array",
+          "x-omitempty": true,
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "x-omitempty": true,
       "type": "object"
     },
     "VectorConfig": {
@@ -1820,6 +1726,9 @@
           },
           "type": "array",
           "x-omitempty": true
+        },
+        "textAnalyzer": {
+          "$ref": "#/definitions/TextAnalyzerConfig"
         }
       },
       "type": "object"
@@ -2577,6 +2486,52 @@
         "payload": {
           "description": "The payload of the task.",
           "type": "object"
+        },
+        "units": {
+          "description": "Units of the task. Only present for tasks that use unit tracking.",
+          "type": "array",
+          "x-omitempty": true,
+          "items": {
+            "$ref": "#/definitions/DistributedTaskUnit"
+          }
+        }
+      }
+    },
+    "DistributedTaskUnit": {
+      "description": "A unit of a distributed task.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "The ID of the unit.",
+          "type": "string"
+        },
+        "nodeId": {
+          "description": "The node that owns this unit.",
+          "type": "string"
+        },
+        "status": {
+          "description": "The status of the unit.",
+          "type": "string"
+        },
+        "progress": {
+          "description": "The progress of the unit (0.0 to 1.0).",
+          "type": "number",
+          "format": "float"
+        },
+        "error": {
+          "description": "The error message if the unit failed.",
+          "type": "string",
+          "x-omitempty": true
+        },
+        "updatedAt": {
+          "description": "The time when the unit was last updated.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "finishedAt": {
+          "description": "The time when the unit finished.",
+          "type": "string",
+          "format": "date-time"
         }
       }
     },
@@ -3518,7 +3473,7 @@
     },
     "description": "# Introduction<br/> Weaviate is an open source, AI-native vector database that helps developers create intuitive and reliable AI-powered applications. <br/> ### Base Path <br/>The base path for the Weaviate server is structured as `[YOUR-WEAVIATE-HOST]:[PORT]/v1`. As an example, if you wish to access the `schema` endpoint on a local instance, you would navigate to `http://localhost:8080/v1/schema`. Ensure you replace `[YOUR-WEAVIATE-HOST]` and `[PORT]` with your actual server host and port number respectively. <br/> ### Questions? <br/>If you have any comments or questions, please feel free to reach out to us at the community forum [https://forum.weaviate.io/](https://forum.weaviate.io/). <br/>### Issues? <br/>If you find a bug or want to file a feature request, please open an issue on our GitHub repository for [Weaviate](https://github.com/weaviate/weaviate). <br/>### Need more documentation? <br/>For a quickstart, code examples, concepts and more, please visit our [documentation page](https://docs.weaviate.io/weaviate).",
     "title": "Weaviate REST API",
-    "version": "1.37.0-dev"
+    "version": "1.37.0-rc.0"
   },
   "parameters": {
     "CommonAfterParameterQuery": {
@@ -7751,6 +7706,58 @@
         "x-available-in-websocket": false
       }
     },
+    "/tokenize": {
+      "post": {
+        "summary": "Tokenize text",
+        "description": "Tokenizes the provided text using the specified tokenization method. This is a stateless utility endpoint useful for debugging and understanding how text will be processed during indexing and querying. The response includes both the indexed tokens (as stored in the inverted index) and query tokens (after optional stopword removal).",
+        "operationId": "tokenize",
+        "tags": [
+          "tokenize"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TokenizeRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully tokenized the text.",
+            "schema": {
+              "$ref": "#/definitions/TokenizeResponse"
+            }
+          },
+          "400": {
+            "description": "Invalid or malformed request body."
+          },
+          "401": {
+            "description": "Unauthorized or invalid credentials."
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "422": {
+            "description": "Request binding or validation error. Check the ErrorResponse for details.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred while tokenizing the text. Check the ErrorResponse for details.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
     "/schema": {
       "get": {
         "summary": "Get all collection definitions",
@@ -8134,6 +8141,133 @@
           },
           "500": {
             "description": "An error occurred while deleting the index. Check the ErrorResponse for details.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/schema/{className}/properties/{propertyName}/tokenize": {
+      "post": {
+        "summary": "Tokenize text using a property's configuration",
+        "description": "Tokenizes the provided text using the tokenization method configured for the specified property. This endpoint automatically applies the property's tokenization setting and the collection's stopword configuration, making it useful for understanding exactly how text will be processed for a given property during indexing and querying.",
+        "operationId": "schema.objects.properties.tokenize",
+        "x-serviceIds": [
+          "weaviate.local.query.meta"
+        ],
+        "tags": [
+          "schema"
+        ],
+        "parameters": [
+          {
+            "name": "className",
+            "description": "The name of the collection (class) containing the property.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "propertyName",
+            "description": "The name of the property whose tokenization configuration should be used.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PropertyTokenizeRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully tokenized the text using the property's configuration.",
+            "schema": {
+              "$ref": "#/definitions/TokenizeResponse"
+            }
+          },
+          "400": {
+            "description": "Invalid request body, missing required fields, or property does not have tokenization configured."
+          },
+          "401": {
+            "description": "Unauthorized or invalid credentials."
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "404": {
+            "description": "Collection or property not found."
+          },
+          "422": {
+            "description": "Validation error, such as invalid class or property configuration for tokenization.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Unexpected server error while tokenizing the text.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/schema/{className}/vectors/{vectorIndexName}/index": {
+      "delete": {
+        "summary": "Delete a collection's vector index.",
+        "description": "Deletes a specific vector index within a collection (`className`). The vector index to delete is identified by `vectorIndexName`.",
+        "operationId": "schema.objects.vectors.delete",
+        "x-serviceIds": [
+          "weaviate.local.manipulate.meta"
+        ],
+        "tags": [
+          "schema"
+        ],
+        "parameters": [
+          {
+            "name": "className",
+            "description": "The name of the collection (class) containing the property.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "vectorIndexName",
+            "description": "The name of the vector index.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Vector index deleted successfully."
+          },
+          "401": {
+            "description": "Unauthorized or invalid credentials."
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "422": {
+            "description": "Invalid vector index or collection provided.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "An error occurred while deleting the vector index. Check the ErrorResponse for details.",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
@@ -9416,6 +9550,12 @@
               "$ref": "#/definitions/ErrorResponse"
             }
           },
+          "409": {
+            "description": "Export already exists or another export is already in progress",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "422": {
             "description": "Invalid export request",
             "schema": {
@@ -9458,13 +9598,6 @@
             "description": "The unique identifier of the export."
           },
           {
-            "name": "bucket",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "description": "Optional bucket name where the export is stored. If not specified, uses the backend's default bucket."
-          },
-          {
             "name": "path",
             "in": "query",
             "required": false,
@@ -9490,6 +9623,12 @@
           },
           "404": {
             "description": "Export not found",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "422": {
+            "description": "Invalid request (e.g., unsupported backend)",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
@@ -9528,13 +9667,6 @@
             "description": "The unique identifier of the export to cancel."
           },
           {
-            "name": "bucket",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "description": "Optional bucket name where the export is stored."
-          },
-          {
             "name": "path",
             "in": "query",
             "required": false,
@@ -9563,6 +9695,12 @@
           },
           "409": {
             "description": "Export has already finished and cannot be cancelled",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "422": {
+            "description": "Invalid request (e.g., unsupported backend)",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
@@ -9869,6 +10007,35 @@
           "classifications"
         ]
       }
+    },
+    "/mcp": {
+      "post": {
+        "description": "MCP Streamable HTTP endpoint. Handles JSON-RPC requests for tool discovery and invocation.",
+        "tags": ["mcp"],
+        "operationId": "mcp.post",
+        "consumes": ["application/json"],
+        "produces": ["application/json", "text/event-stream"],
+        "responses": {
+          "200": { "description": "JSON-RPC response or SSE stream" }
+        }
+      },
+      "get": {
+        "description": "Opens an SSE stream for receiving MCP server-sent events.",
+        "tags": ["mcp"],
+        "operationId": "mcp.get",
+        "produces": ["text/event-stream"],
+        "responses": {
+          "200": { "description": "SSE event stream" }
+        }
+      },
+      "delete": {
+        "description": "Terminates an MCP session.",
+        "tags": ["mcp"],
+        "operationId": "mcp.delete",
+        "responses": {
+          "200": { "description": "Session terminated" }
+        }
+      }
     }
   },
   "produces": [
@@ -9930,6 +10097,10 @@
     {
       "name": "replication",
       "description": "Operations related to managing data replication, including initiating and monitoring shard replica movements between nodes, querying current sharding states, and managing the lifecycle of replication tasks."
+    },
+    {
+      "name": "mcp",
+      "description": "Model Context Protocol (MCP) endpoint. Provides tool discovery and invocation for LLM agents via the MCP Streamable HTTP transport."
     }
   ]
 }

--- a/src/Weaviate.Client/Weaviate.Client.csproj
+++ b/src/Weaviate.Client/Weaviate.Client.csproj
@@ -53,6 +53,7 @@
     <Protobuf Include="gRPC\proto\v1\batch_delete.proto" GrpcServices="Client" AdditionalImportDirs="gRPC\proto" Access="Internal" />
     <Protobuf Include="gRPC\proto\v1\generative.proto" GrpcServices="Client" AdditionalImportDirs="gRPC\proto" Access="Internal" />
     <Protobuf Include="gRPC\proto\v1\properties.proto" GrpcServices="Client" AdditionalImportDirs="gRPC\proto" Access="Internal" />
+    <Protobuf Include="gRPC\proto\v1\health_weaviate.proto" GrpcServices="Client" AdditionalImportDirs="gRPC\proto" Access="Internal" />
     <Protobuf Include="gRPC\proto\v1\search_get.proto" GrpcServices="Client" AdditionalImportDirs="gRPC\proto" Access="Internal" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Weaviate.Client/gRPC/proto/v1/base_search.proto
+++ b/src/Weaviate.Client/gRPC/proto/v1/base_search.proto
@@ -36,6 +36,16 @@ message VectorForTarget {
   repeated Vectors vectors = 3;
 }
 
+message Selection {
+  message MMR {
+    optional uint32 limit = 1;
+    optional float balance = 2;
+  }
+  oneof selection {
+    MMR mmr = 1;
+  }
+}
+
 message SearchOperatorOptions {
   enum Operator {
     OPERATOR_UNSPECIFIED = 0;
@@ -65,6 +75,10 @@ message Hybrid {
   Targets targets = 10;
   optional SearchOperatorOptions bm25_search_operator = 11;
   optional float alpha_param = 12;
+  // if true, alpha_param is used instead of alpha.
+  // This is for backward compatibility, as alpha was used before alpha_param was introduced.
+  bool use_alpha_param = 13;
+  optional Selection selection = 14;
 
   // only vector distance, but keep it extendable
   oneof threshold {
@@ -85,6 +99,7 @@ message NearVector {
   map <string, bytes> vector_per_target = 7 [deprecated = true]; // deprecated in 1.26.2 - use vector_for_targets
   repeated VectorForTarget vector_for_targets = 8;
   repeated Vectors vectors = 9;
+  optional Selection selection = 10;
 }
 
 message NearObject {
@@ -93,6 +108,7 @@ message NearObject {
   optional double distance = 3;
   repeated string target_vectors = 4 [deprecated = true];  // deprecated in 1.26 - use targets
   Targets targets = 5;
+  optional Selection selection = 6;
 }
 
 message NearTextSearch {
@@ -110,6 +126,7 @@ message NearTextSearch {
   optional Move move_away = 5;
   repeated string target_vectors = 6 [deprecated = true];  // deprecated in 1.26 - use targets
   Targets targets = 7;
+  optional Selection selection = 8;
 };
 
 message NearImageSearch {
@@ -118,6 +135,7 @@ message NearImageSearch {
   optional double distance = 3;
   repeated string target_vectors = 4 [deprecated = true];  // deprecated in 1.26 - use targets
   Targets targets = 5;
+  optional Selection selection = 6;
 };
 
 message NearAudioSearch {
@@ -126,6 +144,7 @@ message NearAudioSearch {
   optional double distance = 3;
   repeated string target_vectors = 4 [deprecated = true];  // deprecated in 1.26 - use targets
   Targets targets = 5;
+  optional Selection selection = 6;
 };
 
 message NearVideoSearch {
@@ -134,6 +153,7 @@ message NearVideoSearch {
   optional double distance = 3;
   repeated string target_vectors = 4 [deprecated = true];  // deprecated in 1.26 - use targets
   Targets targets = 5;
+  optional Selection selection = 6;
 };
 
 message NearDepthSearch {
@@ -142,6 +162,7 @@ message NearDepthSearch {
   optional double distance = 3;
   repeated string target_vectors = 4 [deprecated = true];  // deprecated in 1.26 - use targets
   Targets targets = 5;
+  optional Selection selection = 6;
 }
 
 message NearThermalSearch {
@@ -150,6 +171,7 @@ message NearThermalSearch {
   optional double distance = 3;
   repeated string target_vectors = 4 [deprecated = true];  // deprecated in 1.26 - use targets
   Targets targets = 5;
+  optional Selection selection = 6;
 }
 
 message NearIMUSearch {
@@ -158,6 +180,7 @@ message NearIMUSearch {
   optional double distance = 3;
   repeated string target_vectors = 4 [deprecated = true];  // deprecated in 1.26 - use targets
   Targets targets = 5;
+  optional Selection selection = 6;
 }
 
 message BM25 {

--- a/src/Weaviate.Client/gRPC/proto/v1/search_get.proto
+++ b/src/Weaviate.Client/gRPC/proto/v1/search_get.proto
@@ -84,6 +84,9 @@ message MetadataRequest {
   bool explain_score = 8;
   bool is_consistent = 9;
   repeated string vectors = 10;
+  // query_profile enables per-shard query profiling. When true, the response includes
+  // timing breakdowns for each shard and search type.
+  bool query_profile = 11;
 }
 
 message PropertiesRequest {
@@ -117,6 +120,29 @@ message SearchReply {
   optional string generative_grouped_result = 3 [deprecated = true];
   repeated GroupByResult group_by_results = 4;
   optional GenerativeResult generative_grouped_results = 5;
+  optional QueryProfile query_profile = 6;
+}
+
+// QueryProfile contains per-shard profiling data for a search query.
+// Only populated when MetadataRequest.profile is true.
+message QueryProfile {
+  // SearchProfile holds the profiling details for a single search type within a shard.
+  message SearchProfile {
+    // details contains human-readable profiling metrics keyed by metric name.
+    map<string, string> details = 1;
+  }
+
+  // ShardProfile holds profiling data for a single shard's contribution to a search query.
+  message ShardProfile {
+    // name is the identifier of the shard that was searched.
+    string name = 1;
+    // node is the name of the cluster node that executed this shard search.
+    string node = 2;
+    // searches maps search type (e.g., "vector", "keyword") to its profiling details.
+    map<string, SearchProfile> searches = 3;
+  }
+
+  repeated ShardProfile shards = 1;
 }
 
 message RerankReply {


### PR DESCRIPTION
## Summary

- Runs `tools/proto_sync.sh stable/v1.36` to pull latest proto definitions from the Weaviate v1.36 stable branch
- Updates OpenAPI spec (`openapi.json`) and regenerated DTO models (`Models.g.cs`) for v1.36
- Registers newly introduced `health_weaviate.proto` in the project file so Grpc.Tools compiles it
- Fixes `PermissionsScopeTests.AllPermissionActions_AreMentioned` for the new `Manage_mcp` permission action added in v1.36

This is a prerequisite for the query profiling feature (weaviate/csharp-client#315).

## Test plan

- [ ] `dotnet build` passes with no errors
- [ ] Unit tests pass: `dotnet test --filter "FullyQualifiedName~Unit"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)