### PR TITLE
feat(export): add collection export support (Weaviate 1.37+)

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       ENABLE_MODULES: text2vec-transformers,text2vec-cohere,backup-filesystem,generative-dummy,generative-anyscale,reranker-dummy,reranker-cohere,text2vec-ollama,generative-ollama
       BACKUP_FILESYSTEM_PATH: "/tmp/backups"
       EXPORT_ENABLED: 'true'
+      EXPORT_DEFAULT_PATH: "/tmp/exports"
       CLUSTER_GOSSIP_BIND_PORT: "7100"
       CLUSTER_DATA_BIND_PORT: "7101"
       CLUSTER_HOSTNAME: "singlenode"

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
       ENABLE_MODULES: text2vec-transformers,text2vec-cohere,backup-filesystem,generative-dummy,generative-anyscale,reranker-dummy,reranker-cohere,text2vec-ollama,generative-ollama
       BACKUP_FILESYSTEM_PATH: "/tmp/backups"
+      EXPORT_ENABLED: 'true'
       CLUSTER_GOSSIP_BIND_PORT: "7100"
       CLUSTER_DATA_BIND_PORT: "7101"
       CLUSTER_HOSTNAME: "singlenode"

--- a/src/Weaviate.Client.Tests/Integration/TestExports.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestExports.cs
@@ -30,6 +30,7 @@ public class TestExports : IntegrationTests
             new ExportCreateRequest(
                 $"export-sync-{Guid.NewGuid():N}",
                 _backend,
+                ExportFileFormat.Parquet,
                 IncludeCollections: [collection.Name]
             ),
             timeout: TimeSpan.FromMinutes(2),
@@ -50,6 +51,7 @@ public class TestExports : IntegrationTests
             new ExportCreateRequest(
                 $"export-async-{Guid.NewGuid():N}",
                 _backend,
+                ExportFileFormat.Parquet,
                 IncludeCollections: [collection.Name]
             ),
             ct
@@ -72,7 +74,12 @@ public class TestExports : IntegrationTests
         var exportId = $"export-status-{Guid.NewGuid():N}";
 
         await _weaviate.Export.CreateSync(
-            new ExportCreateRequest(exportId, _backend, IncludeCollections: [collection.Name]),
+            new ExportCreateRequest(
+                exportId,
+                _backend,
+                ExportFileFormat.Parquet,
+                IncludeCollections: [collection.Name]
+            ),
             timeout: TimeSpan.FromMinutes(2),
             cancellationToken: ct
         );
@@ -93,35 +100,39 @@ public class TestExports : IntegrationTests
             new ExportCreateRequest(
                 $"export-cancel-{Guid.NewGuid():N}",
                 _backend,
+                ExportFileFormat.Parquet,
                 IncludeCollections: [collection.Name]
             ),
             ct
         );
 
         // Cancel immediately — may already have completed for small collections.
-        // Server responds with 409 Conflict when the export has already finished,
-        // or 404 Not Found if the record is no longer available.
+        // Cancel returns false when the export has already finished (409 Conflict);
+        // 404 Not Found still throws if the record is no longer available.
+        bool canceled;
         try
         {
-            await _weaviate.Export.Cancel(_backend, operation.Current.Id, ct);
-        }
-        catch (WeaviateConflictException)
-        {
-            // Export already finished — can't cancel a terminal export.
+            canceled = await _weaviate.Export.Cancel(_backend, operation.Current.Id, ct);
         }
         catch (WeaviateNotFoundException)
         {
-            // Export record no longer available.
+            // Export record no longer available — treat as canceled.
+            return;
         }
 
         try
         {
             var status = await _weaviate.Export.GetStatus(_backend, operation.Current.Id, ct);
 
-            Assert.True(
-                status.Status is ExportStatus.Canceled or ExportStatus.Success,
-                $"Expected Canceled or Success but got {status.Status}"
-            );
+            if (canceled)
+            {
+                Assert.Equal(ExportStatus.Canceled, status.Status);
+            }
+            else
+            {
+                // 409: export reached a terminal state before we could cancel.
+                Assert.Equal(ExportStatus.Success, status.Status);
+            }
         }
         catch (WeaviateNotFoundException)
         {

--- a/src/Weaviate.Client.Tests/Integration/TestExports.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestExports.cs
@@ -1,0 +1,122 @@
+namespace Weaviate.Client.Tests.Integration;
+
+using Weaviate.Client.Models;
+
+/// <summary>
+/// Integration tests for ExportClient.
+/// Requires Weaviate 1.37.0+ with export support enabled.
+/// </summary>
+[Trait("Category", "Slow")]
+[Collection("TestExports")]
+[CollectionDefinition("TestExports", DisableParallelization = true)]
+public class TestExports : IntegrationTests
+{
+    static readonly BackupBackend _backend = new FilesystemBackend();
+
+    public override async ValueTask InitializeAsync()
+    {
+        await base.InitializeAsync();
+
+        RequireVersion("1.37.0");
+    }
+
+    [Fact]
+    public async Task CreateSync_CompletesSuccessfully()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var collectionName = "ExportTest1";
+        await CollectionFactory(collectionName);
+
+        var export = await _weaviate.Export.CreateSync(
+            new ExportCreateRequest(
+                $"export-sync-{Guid.NewGuid():N}",
+                _backend,
+                IncludeCollections: [collectionName]
+            ),
+            timeout: TimeSpan.FromMinutes(2),
+            cancellationToken: ct
+        );
+
+        Assert.Equal(ExportStatus.Success, export.Status);
+        Assert.NotNull(export.CompletedAt);
+    }
+
+    [Fact]
+    public async Task Create_ThenWaitForCompletion()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var collectionName = "ExportTest2";
+        await CollectionFactory(collectionName);
+
+        await using var operation = await _weaviate.Export.Create(
+            new ExportCreateRequest(
+                $"export-async-{Guid.NewGuid():N}",
+                _backend,
+                IncludeCollections: [collectionName]
+            ),
+            ct
+        );
+
+        Assert.NotNull(operation.Current);
+
+        var result = await operation.WaitForCompletion(TimeSpan.FromMinutes(2), ct);
+
+        Assert.Equal(ExportStatus.Success, result.Status);
+        Assert.True(operation.IsCompleted);
+        Assert.True(operation.IsSuccessful);
+    }
+
+    [Fact]
+    public async Task GetStatus_ReturnsExportInfo()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var collectionName = "ExportTest3";
+        await CollectionFactory(collectionName);
+        var exportId = $"export-status-{Guid.NewGuid():N}";
+
+        await _weaviate.Export.CreateSync(
+            new ExportCreateRequest(exportId, _backend, IncludeCollections: [collectionName]),
+            timeout: TimeSpan.FromMinutes(2),
+            cancellationToken: ct
+        );
+
+        var status = await _weaviate.Export.GetStatus(_backend, exportId, ct);
+
+        Assert.Equal(exportId, status.Id);
+        Assert.Equal(ExportStatus.Success, status.Status);
+    }
+
+    [Fact]
+    public async Task Cancel_StopsRunningExport()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var collectionName = "ExportTest4";
+        await CollectionFactory(collectionName);
+
+        await using var operation = await _weaviate.Export.Create(
+            new ExportCreateRequest(
+                $"export-cancel-{Guid.NewGuid():N}",
+                _backend,
+                IncludeCollections: [collectionName]
+            ),
+            ct
+        );
+
+        // Cancel immediately — may already have completed for small collections
+        try
+        {
+            await _weaviate.Export.Cancel(_backend, operation.Current.Id, ct);
+        }
+        catch (Rest.WeaviateRestClientException)
+        {
+            // Export may have already completed
+        }
+
+        var status = await _weaviate.Export.GetStatus(_backend, operation.Current.Id, ct);
+
+        Assert.True(
+            status.Status is ExportStatus.Canceled or ExportStatus.Success,
+            $"Expected Canceled or Success but got {status.Status}"
+        );
+    }
+}

--- a/src/Weaviate.Client.Tests/Integration/TestExports.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestExports.cs
@@ -24,14 +24,13 @@ public class TestExports : IntegrationTests
     public async Task CreateSync_CompletesSuccessfully()
     {
         var ct = TestContext.Current.CancellationToken;
-        var collectionName = "ExportTest1";
-        await CollectionFactory(collectionName);
+        var collection = await CollectionFactory("ExportTest1");
 
         var export = await _weaviate.Export.CreateSync(
             new ExportCreateRequest(
                 $"export-sync-{Guid.NewGuid():N}",
                 _backend,
-                IncludeCollections: [collectionName]
+                IncludeCollections: [collection.Name]
             ),
             timeout: TimeSpan.FromMinutes(2),
             cancellationToken: ct
@@ -45,14 +44,13 @@ public class TestExports : IntegrationTests
     public async Task Create_ThenWaitForCompletion()
     {
         var ct = TestContext.Current.CancellationToken;
-        var collectionName = "ExportTest2";
-        await CollectionFactory(collectionName);
+        var collection = await CollectionFactory("ExportTest2");
 
         await using var operation = await _weaviate.Export.Create(
             new ExportCreateRequest(
                 $"export-async-{Guid.NewGuid():N}",
                 _backend,
-                IncludeCollections: [collectionName]
+                IncludeCollections: [collection.Name]
             ),
             ct
         );
@@ -70,12 +68,11 @@ public class TestExports : IntegrationTests
     public async Task GetStatus_ReturnsExportInfo()
     {
         var ct = TestContext.Current.CancellationToken;
-        var collectionName = "ExportTest3";
-        await CollectionFactory(collectionName);
+        var collection = await CollectionFactory("ExportTest3");
         var exportId = $"export-status-{Guid.NewGuid():N}";
 
         await _weaviate.Export.CreateSync(
-            new ExportCreateRequest(exportId, _backend, IncludeCollections: [collectionName]),
+            new ExportCreateRequest(exportId, _backend, IncludeCollections: [collection.Name]),
             timeout: TimeSpan.FromMinutes(2),
             cancellationToken: ct
         );
@@ -90,14 +87,13 @@ public class TestExports : IntegrationTests
     public async Task Cancel_StopsRunningExport()
     {
         var ct = TestContext.Current.CancellationToken;
-        var collectionName = "ExportTest4";
-        await CollectionFactory(collectionName);
+        var collection = await CollectionFactory("ExportTest4");
 
         await using var operation = await _weaviate.Export.Create(
             new ExportCreateRequest(
                 $"export-cancel-{Guid.NewGuid():N}",
                 _backend,
-                IncludeCollections: [collectionName]
+                IncludeCollections: [collection.Name]
             ),
             ct
         );

--- a/src/Weaviate.Client.Tests/Integration/TestExports.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestExports.cs
@@ -102,21 +102,34 @@ public class TestExports : IntegrationTests
             ct
         );
 
-        // Cancel immediately — may already have completed for small collections
+        // Cancel immediately — may already have completed for small collections.
+        // Server responds with 409 Conflict when the export has already finished,
+        // or 404 Not Found if the record is no longer available.
         try
         {
             await _weaviate.Export.Cancel(_backend, operation.Current.Id, ct);
         }
-        catch (Rest.WeaviateRestClientException)
+        catch (WeaviateConflictException)
         {
-            // Export may have already completed
+            // Export already finished — can't cancel a terminal export.
+        }
+        catch (WeaviateNotFoundException)
+        {
+            // Export record no longer available.
         }
 
-        var status = await _weaviate.Export.GetStatus(_backend, operation.Current.Id, ct);
+        try
+        {
+            var status = await _weaviate.Export.GetStatus(_backend, operation.Current.Id, ct);
 
-        Assert.True(
-            status.Status is ExportStatus.Canceled or ExportStatus.Success,
-            $"Expected Canceled or Success but got {status.Status}"
-        );
+            Assert.True(
+                status.Status is ExportStatus.Canceled or ExportStatus.Success,
+                $"Expected Canceled or Success but got {status.Status}"
+            );
+        }
+        catch (WeaviateNotFoundException)
+        {
+            // Treat vanished export as successfully canceled.
+        }
     }
 }

--- a/src/Weaviate.Client.Tests/Unit/TestExportClient.cs
+++ b/src/Weaviate.Client.Tests/Unit/TestExportClient.cs
@@ -1,0 +1,272 @@
+using System.Net;
+using Weaviate.Client.Models;
+using Weaviate.Client.Tests.Unit.Mocks;
+
+namespace Weaviate.Client.Tests.Unit;
+
+/// <summary>
+/// Unit tests for ExportClient, focusing on HTTP request routing and DTO-to-model mapping.
+/// </summary>
+public class TestExportClient
+{
+    /// <summary>
+    /// Create must issue a POST to /v1/export/filesystem with the correct JSON body.
+    /// </summary>
+    [Fact]
+    public async Task Create_SendsPostToExportEndpoint()
+    {
+        var json = """
+            {
+                "id": "my-export",
+                "backend": "filesystem",
+                "status": "STARTED",
+                "classes": ["Article"]
+            }
+            """;
+
+        var (client, handler) = MockWeaviateClient.CreateWithMockHandler(
+            syncHandler: _ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json"),
+            },
+            serverVersion: "1.37.0"
+        );
+
+        await using var operation = await client.Export.Create(
+            new ExportCreateRequest("my-export", new FilesystemBackend()),
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.NotNull(handler.LastRequest);
+        handler
+            .LastRequest!.ShouldHaveMethod(HttpMethod.Post)
+            .ShouldHavePath("/v1/export/filesystem");
+    }
+
+    /// <summary>
+    /// GetStatus must issue a GET to /v1/export/filesystem/{id}.
+    /// </summary>
+    [Fact]
+    public async Task GetStatus_SendsGetToStatusEndpoint()
+    {
+        var json = """
+            {
+                "id": "my-export",
+                "backend": "filesystem",
+                "status": "SUCCESS",
+                "startedAt": "2026-01-01T00:00:00Z",
+                "completedAt": "2026-01-01T00:01:00Z",
+                "tookInMs": 60000
+            }
+            """;
+
+        var (client, handler) = MockWeaviateClient.CreateWithMockHandler(
+            syncHandler: _ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json"),
+            },
+            serverVersion: "1.37.0"
+        );
+
+        var export = await client.Export.GetStatus(
+            new FilesystemBackend(),
+            "my-export",
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.NotNull(handler.LastRequest);
+        handler
+            .LastRequest!.ShouldHaveMethod(HttpMethod.Get)
+            .ShouldHavePath("/v1/export/filesystem/my-export");
+
+        Assert.Equal("my-export", export.Id);
+        Assert.Equal(ExportStatus.Success, export.Status);
+        Assert.Equal(60000, export.TookInMs);
+    }
+
+    /// <summary>
+    /// Cancel must issue a DELETE to /v1/export/filesystem/{id}.
+    /// </summary>
+    [Fact]
+    public async Task Cancel_SendsDeleteToExportEndpoint()
+    {
+        var (client, handler) = MockWeaviateClient.CreateWithMockHandler(
+            syncHandler: _ => new HttpResponseMessage(HttpStatusCode.NoContent),
+            serverVersion: "1.37.0"
+        );
+
+        await client.Export.Cancel(
+            new FilesystemBackend(),
+            "my-export",
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.NotNull(handler.LastRequest);
+        handler
+            .LastRequest!.ShouldHaveMethod(HttpMethod.Delete)
+            .ShouldHavePath("/v1/export/filesystem/my-export");
+    }
+
+    /// <summary>
+    /// Status parsing should correctly map all known status strings.
+    /// </summary>
+    [Theory]
+    [InlineData("STARTED", ExportStatus.Started)]
+    [InlineData("TRANSFERRING", ExportStatus.Transferring)]
+    [InlineData("SUCCESS", ExportStatus.Success)]
+    [InlineData("FAILED", ExportStatus.Failed)]
+    [InlineData("CANCELED", ExportStatus.Canceled)]
+    public async Task GetStatus_ParsesStatusCorrectly(string statusString, ExportStatus expected)
+    {
+        var json = $$"""
+            {
+                "id": "my-export",
+                "backend": "filesystem",
+                "status": "{{statusString}}"
+            }
+            """;
+
+        var (client, _) = MockWeaviateClient.CreateWithMockHandler(
+            syncHandler: _ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json"),
+            },
+            serverVersion: "1.37.0"
+        );
+
+        var export = await client.Export.GetStatus(
+            new FilesystemBackend(),
+            "my-export",
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(expected, export.Status);
+    }
+
+    /// <summary>
+    /// GetStatus should correctly deserialize shard progress from the response.
+    /// </summary>
+    [Fact]
+    public async Task GetStatus_DeserializesShardStatus()
+    {
+        var json = """
+            {
+                "id": "my-export",
+                "backend": "filesystem",
+                "status": "TRANSFERRING",
+                "shardStatus": {
+                    "Article": {
+                        "shard0": {
+                            "status": "TRANSFERRING",
+                            "objectsExported": 42
+                        },
+                        "shard1": {
+                            "status": "SUCCESS",
+                            "objectsExported": 100
+                        }
+                    }
+                }
+            }
+            """;
+
+        var (client, _) = MockWeaviateClient.CreateWithMockHandler(
+            syncHandler: _ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json"),
+            },
+            serverVersion: "1.37.0"
+        );
+
+        var export = await client.Export.GetStatus(
+            new FilesystemBackend(),
+            "my-export",
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.NotNull(export.ShardStatus);
+        Assert.True(export.ShardStatus!.ContainsKey("Article"));
+        var articleShards = export.ShardStatus["Article"];
+        Assert.Equal(2, articleShards.Count);
+        Assert.Equal(42, articleShards["shard0"].ObjectsExported);
+        Assert.Equal(100, articleShards["shard1"].ObjectsExported);
+    }
+
+    /// <summary>
+    /// Create with include/exclude collections should send the correct JSON body.
+    /// </summary>
+    [Fact]
+    public async Task Create_WithIncludeCollections_SendsCorrectBody()
+    {
+        var json = """
+            {
+                "id": "my-export",
+                "backend": "filesystem",
+                "status": "STARTED",
+                "classes": ["Article"]
+            }
+            """;
+
+        string? requestBody = null;
+        var (client, _) = MockWeaviateClient.CreateWithMockHandler(
+            handlerWithToken: async (req, ct) =>
+            {
+                if (req.Method == HttpMethod.Post)
+                {
+                    requestBody = await req.Content!.ReadAsStringAsync(ct);
+                }
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        json,
+                        System.Text.Encoding.UTF8,
+                        "application/json"
+                    ),
+                };
+            },
+            serverVersion: "1.37.0"
+        );
+
+        await using var operation = await client.Export.Create(
+            new ExportCreateRequest(
+                "my-export",
+                new FilesystemBackend(),
+                IncludeCollections: ["Article", "Author"]
+            ),
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.NotNull(requestBody);
+        Assert.Contains("\"include\":[\"Article\",\"Author\"]", requestBody);
+    }
+
+    /// <summary>
+    /// Create with S3 backend uses correct endpoint path.
+    /// </summary>
+    [Fact]
+    public async Task Create_WithS3Backend_UsesCorrectEndpoint()
+    {
+        var json = """
+            {
+                "id": "my-export",
+                "backend": "s3",
+                "status": "STARTED"
+            }
+            """;
+
+        var (client, handler) = MockWeaviateClient.CreateWithMockHandler(
+            syncHandler: _ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json"),
+            },
+            serverVersion: "1.37.0"
+        );
+
+        await using var operation = await client.Export.Create(
+            new ExportCreateRequest("my-export", ObjectStorageBackend.S3()),
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.NotNull(handler.LastRequest);
+        handler.LastRequest!.ShouldHaveMethod(HttpMethod.Post).ShouldHavePath("/v1/export/s3");
+    }
+}

--- a/src/Weaviate.Client.Tests/Unit/TestExportClient.cs
+++ b/src/Weaviate.Client.Tests/Unit/TestExportClient.cs
@@ -33,7 +33,7 @@ public class TestExportClient
         );
 
         await using var operation = await client.Export.Create(
-            new ExportCreateRequest("my-export", new FilesystemBackend()),
+            new ExportCreateRequest("my-export", new FilesystemBackend(), ExportFileFormat.Parquet),
             TestContext.Current.CancellationToken
         );
 
@@ -85,7 +85,7 @@ public class TestExportClient
     }
 
     /// <summary>
-    /// Cancel must issue a DELETE to /v1/export/filesystem/{id}.
+    /// Cancel must issue a DELETE to /v1/export/filesystem/{id} and return true on 204.
     /// </summary>
     [Fact]
     public async Task Cancel_SendsDeleteToExportEndpoint()
@@ -95,16 +95,58 @@ public class TestExportClient
             serverVersion: "1.37.0"
         );
 
-        await client.Export.Cancel(
+        var canceled = await client.Export.Cancel(
             new FilesystemBackend(),
             "my-export",
             TestContext.Current.CancellationToken
         );
 
+        Assert.True(canceled);
         Assert.NotNull(handler.LastRequest);
         handler
             .LastRequest!.ShouldHaveMethod(HttpMethod.Delete)
             .ShouldHavePath("/v1/export/filesystem/my-export");
+    }
+
+    /// <summary>
+    /// Cancel returns false (no throw) when the server responds 409 Conflict —
+    /// the export reached a terminal state and cannot be canceled.
+    /// </summary>
+    [Fact]
+    public async Task Cancel_OnConflict_ReturnsFalseWithoutThrowing()
+    {
+        var (client, _) = MockWeaviateClient.CreateWithMockHandler(
+            syncHandler: _ => new HttpResponseMessage(HttpStatusCode.Conflict),
+            serverVersion: "1.37.0"
+        );
+
+        var canceled = await client.Export.Cancel(
+            new FilesystemBackend(),
+            "my-export",
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.False(canceled);
+    }
+
+    /// <summary>
+    /// Cancel still throws on 404 Not Found — the export id is unknown.
+    /// </summary>
+    [Fact]
+    public async Task Cancel_OnNotFound_Throws()
+    {
+        var (client, _) = MockWeaviateClient.CreateWithMockHandler(
+            syncHandler: _ => new HttpResponseMessage(HttpStatusCode.NotFound),
+            serverVersion: "1.37.0"
+        );
+
+        await Assert.ThrowsAsync<WeaviateNotFoundException>(async () =>
+            await client.Export.Cancel(
+                new FilesystemBackend(),
+                "unknown-export",
+                TestContext.Current.CancellationToken
+            )
+        );
     }
 
     /// <summary>
@@ -230,6 +272,7 @@ public class TestExportClient
             new ExportCreateRequest(
                 "my-export",
                 new FilesystemBackend(),
+                ExportFileFormat.Parquet,
                 IncludeCollections: ["Article", "Author"]
             ),
             TestContext.Current.CancellationToken
@@ -262,7 +305,11 @@ public class TestExportClient
         );
 
         await using var operation = await client.Export.Create(
-            new ExportCreateRequest("my-export", ObjectStorageBackend.S3()),
+            new ExportCreateRequest(
+                "my-export",
+                ObjectStorageBackend.S3(),
+                ExportFileFormat.Parquet
+            ),
             TestContext.Current.CancellationToken
         );
 

--- a/src/Weaviate.Client/Enums.cs
+++ b/src/Weaviate.Client/Enums.cs
@@ -42,6 +42,11 @@ public enum ResourceType
     Backup,
 
     /// <summary>
+    /// The export resource type
+    /// </summary>
+    Export,
+
+    /// <summary>
     /// The group resource type
     /// </summary>
     Group,

--- a/src/Weaviate.Client/ExportClient.cs
+++ b/src/Weaviate.Client/ExportClient.cs
@@ -1,0 +1,182 @@
+using Weaviate.Client.Models;
+
+namespace Weaviate.Client;
+
+/// <summary>
+/// Adds export property to WeaviateClient
+/// </summary>
+public partial class WeaviateClient
+{
+    private ExportClient? _exports;
+
+    /// <summary>
+    /// A client for managing collection exports.
+    /// </summary>
+    public ExportClient Export => _exports ??= new(this);
+}
+
+/// <summary>
+/// Provides export operations for Weaviate collections — creation, status tracking, and cancellation.
+/// </summary>
+public class ExportClient
+{
+    private readonly WeaviateClient _client;
+
+    /// <summary>
+    /// Static configuration used for all export operations.
+    /// </summary>
+    public static ExportClientConfig Config { get; set; } = ExportClientConfig.Default;
+
+    internal ExportClient(WeaviateClient client)
+    {
+        _client = client;
+    }
+
+    /// <summary>
+    /// Start creating an export asynchronously.
+    /// Returns an ExportOperation that can be used to track status or wait for completion.
+    /// </summary>
+    [RequiresWeaviateVersion(1, 37, 0)]
+    public async Task<ExportOperation> Create(
+        ExportCreateRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await _client.EnsureVersion<ExportClient>();
+
+        var restRequest = BuildExportCreateRequest(request);
+        var response = await _client.RestClient.ExportCreate(
+            request.Backend.Provider,
+            restRequest,
+            cancellationToken
+        );
+        var model = ToModel(response);
+
+        return new ExportOperation(
+            model,
+            async (ct) => await GetStatus(request.Backend, model.Id, ct),
+            async (ct) => await Cancel(request.Backend, model.Id, ct)
+        );
+    }
+
+    /// <summary>
+    /// Create an export and wait synchronously for completion.
+    /// </summary>
+    [RequiresWeaviateVersion(1, 37, 0)]
+    public async Task<Export> CreateSync(
+        ExportCreateRequest request,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await _client.EnsureVersion<ExportClient>();
+        var operation = await Create(request, cancellationToken);
+        return await operation.WaitForCompletion(timeout, cancellationToken);
+    }
+
+    /// <summary>
+    /// Get status for an export
+    /// </summary>
+    [RequiresWeaviateVersion(1, 37, 0)]
+    public async Task<Export> GetStatus(
+        BackupBackend backend,
+        string id,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await _client.EnsureVersion<ExportClient>();
+
+        var status = await _client.RestClient.ExportGetStatus(
+            backend.Provider,
+            id,
+            cancellationToken
+        );
+        return ToModel(status, backend);
+    }
+
+    /// <summary>
+    /// Cancel a running export
+    /// </summary>
+    [RequiresWeaviateVersion(1, 37, 0)]
+    public async Task Cancel(
+        BackupBackend backend,
+        string id,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await _client.EnsureVersion<ExportClient>();
+
+        await _client.RestClient.ExportCancel(backend.Provider, id, cancellationToken);
+    }
+
+    private static Rest.Dto.ExportCreateRequest BuildExportCreateRequest(
+        ExportCreateRequest request
+    )
+    {
+        return new Rest.Dto.ExportCreateRequest
+        {
+            Id = request.Id,
+            File_format = request.FileFormat switch
+            {
+                ExportFileFormat.Parquet => Rest.Dto.ExportCreateRequestFile_format.Parquet,
+                _ => Rest.Dto.ExportCreateRequestFile_format.Parquet,
+            },
+            Include = request.IncludeCollections?.ToList(),
+            Exclude = request.ExcludeCollections?.ToList(),
+            Config = new Rest.Dto.Config { Path = request.Backend.Path },
+        };
+    }
+
+    private static Export ToModel(Rest.Dto.ExportCreateResponse dto) =>
+        new(
+            dto.Id ?? string.Empty,
+            ParseBackend(dto.Backend),
+            dto.Status?.ToString() ?? string.Empty,
+            dto.Classes?.ToArray(),
+            dto.StartedAt,
+            null,
+            null
+        );
+
+    private static Export ToModel(Rest.Dto.ExportStatusResponse dto, BackupBackend backend) =>
+        new(
+            dto.Id ?? string.Empty,
+            backend,
+            dto.Status?.ToString() ?? string.Empty,
+            dto.Classes?.ToArray(),
+            dto.StartedAt,
+            dto.CompletedAt,
+            dto.Error
+        )
+        {
+            ShardStatus = dto.ShardStatus?.ToDictionary(
+                kvp => kvp.Key,
+                kvp =>
+                    kvp.Value.ToDictionary(
+                        inner => inner.Key,
+                        inner => new ShardProgress(
+                            inner.Value.Status?.ToString() ?? string.Empty,
+                            (int)(inner.Value.ObjectsExported ?? 0),
+                            inner.Value.Error,
+                            inner.Value.SkipReason
+                        )
+                    )
+            ),
+            TookInMs = dto.TookInMs.HasValue ? (int)dto.TookInMs.Value : null,
+        };
+
+    private static BackupBackend ParseBackend(string? backendStr)
+    {
+        var provider = backendStr?.ToLowerInvariant() switch
+        {
+            "filesystem" => BackupStorageProvider.Filesystem,
+            "s3" => BackupStorageProvider.S3,
+            "gcs" => BackupStorageProvider.GCS,
+            "azure" => BackupStorageProvider.Azure,
+            _ => BackupStorageProvider.None,
+        };
+        return provider == BackupStorageProvider.None ? BackupBackend.Empty()
+            : provider == BackupStorageProvider.Filesystem ? new FilesystemBackend()
+            : new ObjectStorageBackend(provider);
+    }
+}

--- a/src/Weaviate.Client/ExportClient.cs
+++ b/src/Weaviate.Client/ExportClient.cs
@@ -95,10 +95,13 @@ public class ExportClient
     }
 
     /// <summary>
-    /// Cancel a running export
+    /// Cancel a running export. Returns <c>true</c> if the cancel request was accepted,
+    /// <c>false</c> if the server responded 409 Conflict (export already in a terminal
+    /// state and cannot be canceled). Throws <see cref="WeaviateNotFoundException"/>
+    /// if the export id is unknown.
     /// </summary>
     [RequiresWeaviateVersion(1, 37, 0)]
-    public async Task Cancel(
+    public async Task<bool> Cancel(
         BackupBackend backend,
         string id,
         CancellationToken cancellationToken = default
@@ -106,7 +109,7 @@ public class ExportClient
     {
         await _client.EnsureVersion<ExportClient>();
 
-        await _client.RestClient.ExportCancel(backend.Provider, id, cancellationToken);
+        return await _client.RestClient.ExportCancel(backend.Provider, id, cancellationToken);
     }
 
     private static Rest.Dto.ExportCreateRequest BuildExportCreateRequest(

--- a/src/Weaviate.Client/ExportClient.cs
+++ b/src/Weaviate.Client/ExportClient.cs
@@ -79,7 +79,7 @@ public class ExportClient
     /// </summary>
     [RequiresWeaviateVersion(1, 37, 0)]
     public async Task<Export> GetStatus(
-        BackupBackend backend,
+        StorageBackend backend,
         string id,
         CancellationToken cancellationToken = default
     )
@@ -102,7 +102,7 @@ public class ExportClient
     /// </summary>
     [RequiresWeaviateVersion(1, 37, 0)]
     public async Task<bool> Cancel(
-        BackupBackend backend,
+        StorageBackend backend,
         string id,
         CancellationToken cancellationToken = default
     )
@@ -141,7 +141,7 @@ public class ExportClient
             null
         );
 
-    private static Export ToModel(Rest.Dto.ExportStatusResponse dto, BackupBackend backend) =>
+    private static Export ToModel(Rest.Dto.ExportStatusResponse dto, StorageBackend backend) =>
         new(
             dto.Id ?? string.Empty,
             backend,
@@ -169,7 +169,7 @@ public class ExportClient
             TookInMs = dto.TookInMs.HasValue ? (int)dto.TookInMs.Value : null,
         };
 
-    private static BackupBackend ParseBackend(string? backendStr)
+    private static StorageBackend ParseBackend(string? backendStr)
     {
         var provider = backendStr?.ToLowerInvariant() switch
         {

--- a/src/Weaviate.Client/ExportClient.cs
+++ b/src/Weaviate.Client/ExportClient.cs
@@ -123,7 +123,6 @@ public class ExportClient
             },
             Include = request.IncludeCollections?.ToList(),
             Exclude = request.ExcludeCollections?.ToList(),
-            Config = new Rest.Dto.Config { Path = request.Backend.Path },
         };
     }
 
@@ -131,6 +130,7 @@ public class ExportClient
         new(
             dto.Id ?? string.Empty,
             ParseBackend(dto.Backend),
+            dto.Path,
             dto.Status?.ToString() ?? string.Empty,
             dto.Classes?.ToArray(),
             dto.StartedAt,
@@ -142,6 +142,7 @@ public class ExportClient
         new(
             dto.Id ?? string.Empty,
             backend,
+            dto.Path,
             dto.Status?.ToString() ?? string.Empty,
             dto.Classes?.ToArray(),
             dto.StartedAt,

--- a/src/Weaviate.Client/ExportClient.cs
+++ b/src/Weaviate.Client/ExportClient.cs
@@ -70,7 +70,7 @@ public class ExportClient
     )
     {
         await _client.EnsureVersion<ExportClient>();
-        var operation = await Create(request, cancellationToken);
+        await using var operation = await Create(request, cancellationToken);
         return await operation.WaitForCompletion(timeout, cancellationToken);
     }
 

--- a/src/Weaviate.Client/Models/Backup.cs
+++ b/src/Weaviate.Client/Models/Backup.cs
@@ -131,20 +131,13 @@ public enum BackupStorageProvider
 }
 
 /// <summary>
-/// Base class for backup backend configurations
+/// Backup-feature view of a storage backend. Inherits the abstract
+/// <see cref="StorageBackend.Provider"/> / <see cref="StorageBackend.Path"/> contract
+/// from <see cref="StorageBackend"/>, and exposes static factories that return
+/// <see cref="BackupBackend"/> for use with <see cref="BackupClient"/>.
 /// </summary>
-public abstract record BackupBackend
+public abstract record BackupBackend : StorageBackend
 {
-    /// <summary>
-    /// The backend storage provider
-    /// </summary>
-    public abstract BackupStorageProvider Provider { get; }
-
-    /// <summary>
-    /// Optional path for the backup location
-    /// </summary>
-    public abstract string? Path { get; }
-
     /// <summary>
     /// Creates an empty backend (no backend specified)
     /// </summary>

--- a/src/Weaviate.Client/Models/Export.cs
+++ b/src/Weaviate.Client/Models/Export.cs
@@ -1,0 +1,125 @@
+using Weaviate.Client.Internal;
+
+namespace Weaviate.Client.Models;
+
+/// <summary>
+/// Specifies the file format for export operations.
+/// </summary>
+public enum ExportFileFormat
+{
+    /// <summary>
+    /// Apache Parquet format
+    /// </summary>
+    [System.Text.Json.Serialization.JsonStringEnumMemberName("parquet")]
+    Parquet,
+}
+
+/// <summary>
+/// Represents the status of an export operation.
+/// </summary>
+public enum ExportStatus
+{
+    /// <summary>
+    /// The status is unknown.
+    /// </summary>
+    Unknown,
+
+    /// <summary>
+    /// The export has started.
+    /// </summary>
+    Started,
+
+    /// <summary>
+    /// The export is transferring data.
+    /// </summary>
+    Transferring,
+
+    /// <summary>
+    /// The export completed successfully.
+    /// </summary>
+    Success,
+
+    /// <summary>
+    /// The export failed.
+    /// </summary>
+    Failed,
+
+    /// <summary>
+    /// The export was canceled.
+    /// </summary>
+    Canceled,
+}
+
+/// <summary>
+/// Provides extension methods for parsing <see cref="ExportStatus"/> values from strings.
+/// </summary>
+public static class ExportStatusExtensions
+{
+    /// <summary>
+    /// Converts a string status to an <see cref="ExportStatus"/> value.
+    /// </summary>
+    /// <param name="status">The status string to parse.</param>
+    /// <returns>The parsed <see cref="ExportStatus"/> value.</returns>
+    public static ExportStatus ToExportStatus(this string? status)
+    {
+        return status?.ToUpperInvariant() switch
+        {
+            "STARTED" => ExportStatus.Started,
+            "TRANSFERRING" => ExportStatus.Transferring,
+            "SUCCESS" => ExportStatus.Success,
+            "FAILED" => ExportStatus.Failed,
+            "CANCELED" => ExportStatus.Canceled,
+            _ => ExportStatus.Unknown,
+        };
+    }
+}
+
+/// <summary>
+/// Represents an export as returned by create/status operations.
+/// </summary>
+public record Export(
+    string Id,
+    BackupBackend Backend,
+    string StatusRaw,
+    string[]? Collections,
+    DateTimeOffset? StartedAt,
+    DateTimeOffset? CompletedAt,
+    string? Error
+)
+{
+    /// <summary>
+    /// Parsed export status
+    /// </summary>
+    public ExportStatus Status => StatusRaw.ToExportStatus();
+
+    /// <summary>
+    /// Per-shard export progress. Outer key is collection, inner key is shard name.
+    /// </summary>
+    public Dictionary<string, Dictionary<string, ShardProgress>>? ShardStatus { get; init; }
+
+    /// <summary>
+    /// Time taken in milliseconds, available after completion.
+    /// </summary>
+    public int? TookInMs { get; init; }
+}
+
+/// <summary>
+/// Represents the progress of a single shard export.
+/// </summary>
+public record ShardProgress(
+    string StatusRaw,
+    int ObjectsExported,
+    string? Error,
+    string? SkipReason
+);
+
+/// <summary>
+/// Represents the options for creating an export operation.
+/// </summary>
+public record ExportCreateRequest(
+    string Id,
+    BackupBackend Backend,
+    ExportFileFormat FileFormat = ExportFileFormat.Parquet,
+    AutoArray<string>? IncludeCollections = null,
+    AutoArray<string>? ExcludeCollections = null
+);

--- a/src/Weaviate.Client/Models/Export.cs
+++ b/src/Weaviate.Client/Models/Export.cs
@@ -80,6 +80,7 @@ public static class ExportStatusExtensions
 public record Export(
     string Id,
     BackupBackend Backend,
+    string? Path,
     string StatusRaw,
     string[]? Collections,
     DateTimeOffset? StartedAt,

--- a/src/Weaviate.Client/Models/Export.cs
+++ b/src/Weaviate.Client/Models/Export.cs
@@ -120,7 +120,7 @@ public record ShardProgress(
 public record ExportCreateRequest(
     string Id,
     BackupBackend Backend,
-    ExportFileFormat FileFormat = ExportFileFormat.Parquet,
+    ExportFileFormat FileFormat,
     AutoArray<string>? IncludeCollections = null,
     AutoArray<string>? ExcludeCollections = null
 );

--- a/src/Weaviate.Client/Models/Export.cs
+++ b/src/Weaviate.Client/Models/Export.cs
@@ -79,7 +79,7 @@ public static class ExportStatusExtensions
 /// </summary>
 public record Export(
     string Id,
-    BackupBackend Backend,
+    StorageBackend Backend,
     string? Path,
     string StatusRaw,
     string[]? Collections,
@@ -119,8 +119,34 @@ public record ShardProgress(
 /// </summary>
 public record ExportCreateRequest(
     string Id,
-    BackupBackend Backend,
+    StorageBackend Backend,
     ExportFileFormat FileFormat,
     AutoArray<string>? IncludeCollections = null,
     AutoArray<string>? ExcludeCollections = null
 );
+
+/// <summary>
+/// Export-feature view of a storage backend. Inherits the abstract
+/// <see cref="StorageBackend.Provider"/> / <see cref="StorageBackend.Path"/> contract
+/// from <see cref="StorageBackend"/>, and exposes static factories under an
+/// export-themed name so the backend choices are discoverable through the export API.
+/// Each factory delegates to the matching <see cref="BackupBackend"/> factory —
+/// exports and backups share the same concrete backend types underneath.
+/// </summary>
+public abstract record ExportBackend : StorageBackend
+{
+    /// <summary>Creates a filesystem export backend.</summary>
+    public static StorageBackend Filesystem(string? path = null) => BackupBackend.Filesystem(path);
+
+    /// <summary>Creates an S3 export backend.</summary>
+    public static StorageBackend S3(string? bucket = null, string? path = null) =>
+        BackupBackend.S3(bucket, path);
+
+    /// <summary>Creates a GCS export backend.</summary>
+    public static StorageBackend GCS(string? bucket = null, string? path = null) =>
+        BackupBackend.GCS(bucket, path);
+
+    /// <summary>Creates an Azure export backend.</summary>
+    public static StorageBackend Azure(string? bucket = null, string? path = null) =>
+        BackupBackend.Azure(bucket, path);
+}

--- a/src/Weaviate.Client/Models/ExportClientConfig.cs
+++ b/src/Weaviate.Client/Models/ExportClientConfig.cs
@@ -1,0 +1,24 @@
+namespace Weaviate.Client.Models;
+
+/// <summary>
+/// Configuration for export client operations (polling interval, timeout).
+/// </summary>
+public record ExportClientConfig
+{
+    /// <summary>
+    /// Default polling interval for checking export status.
+    /// Default: 250ms
+    /// </summary>
+    public TimeSpan PollInterval { get; init; } = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>
+    /// Default timeout for waiting for completion of export operations.
+    /// Default: 10 minutes
+    /// </summary>
+    public TimeSpan Timeout { get; init; } = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    /// Default configuration instance.
+    /// </summary>
+    public static ExportClientConfig Default { get; } = new();
+}

--- a/src/Weaviate.Client/Models/ExportOperation.cs
+++ b/src/Weaviate.Client/Models/ExportOperation.cs
@@ -8,7 +8,7 @@ public class ExportOperation : ExportOperationBase
     internal ExportOperation(
         Export initial,
         Func<CancellationToken, Task<Export>> statusFetcher,
-        Func<CancellationToken, Task> operationCancel
+        Func<CancellationToken, Task<bool>> operationCancel
     )
         : base(initial, statusFetcher, operationCancel) { }
 }

--- a/src/Weaviate.Client/Models/ExportOperation.cs
+++ b/src/Weaviate.Client/Models/ExportOperation.cs
@@ -1,0 +1,14 @@
+namespace Weaviate.Client.Models;
+
+/// <summary>
+/// Represents a running export operation with status tracking and cancellation.
+/// </summary>
+public class ExportOperation : ExportOperationBase
+{
+    internal ExportOperation(
+        Export initial,
+        Func<CancellationToken, Task<Export>> statusFetcher,
+        Func<CancellationToken, Task> operationCancel
+    )
+        : base(initial, statusFetcher, operationCancel) { }
+}

--- a/src/Weaviate.Client/Models/ExportOperationBase.cs
+++ b/src/Weaviate.Client/Models/ExportOperationBase.cs
@@ -163,18 +163,17 @@ public abstract class ExportOperationBase : IDisposable, IAsyncDisposable
         _disposed = true;
     }
 
+    /// <summary>
+    /// Internal disposal called from the background refresh task itself when a terminal status
+    /// is observed. Must NOT Wait() on _backgroundRefreshTask — that would block the very task
+    /// executing this code on its own completion (bounded only by the Wait timeout). The task
+    /// is already exiting because _cts has been canceled and _isCompleted is set, so just
+    /// release the CTS.
+    /// </summary>
     private void DisposeInternal()
     {
         if (_disposed)
             return;
-        try
-        {
-            _backgroundRefreshTask.Wait(ExportClient.Config.PollInterval);
-        }
-        catch (Exception)
-        {
-            // Best-effort disposal
-        }
         _cts.Dispose();
         _disposed = true;
     }

--- a/src/Weaviate.Client/Models/ExportOperationBase.cs
+++ b/src/Weaviate.Client/Models/ExportOperationBase.cs
@@ -1,0 +1,209 @@
+namespace Weaviate.Client.Models;
+
+/// <summary>
+/// Abstract base for export operations, with status polling and cancellation.
+/// </summary>
+public abstract class ExportOperationBase : IDisposable, IAsyncDisposable
+{
+    private readonly Func<CancellationToken, Task<Export>> _statusFetcher;
+    private readonly Func<CancellationToken, Task> _operationCancel;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Task _backgroundRefreshTask;
+    private Export _current;
+    private volatile bool _isCompleted;
+    private volatile bool _isSuccessful;
+    private volatile bool _isCanceled;
+    private bool _disposed;
+
+    protected ExportOperationBase(
+        Export initial,
+        Func<CancellationToken, Task<Export>> statusFetcher,
+        Func<CancellationToken, Task> operationCancel
+    )
+    {
+        _current = initial;
+        _statusFetcher = statusFetcher;
+        _operationCancel = operationCancel;
+        _isCompleted = IsTerminalStatus(initial.Status);
+        _isSuccessful = initial.Status == ExportStatus.Success;
+        _isCanceled = initial.Status == ExportStatus.Canceled;
+        _backgroundRefreshTask = StartBackgroundRefresh();
+    }
+
+    /// <summary>
+    /// Gets the current export status and metadata.
+    /// </summary>
+    public Export Current => _current;
+
+    /// <summary>
+    /// Gets a value indicating whether the export operation has completed (success, failure, or canceled).
+    /// </summary>
+    public bool IsCompleted => _isCompleted;
+
+    /// <summary>
+    /// Gets a value indicating whether the export operation completed successfully.
+    /// </summary>
+    public bool IsSuccessful => _isSuccessful;
+
+    /// <summary>
+    /// Gets a value indicating whether the export operation was canceled.
+    /// </summary>
+    public bool IsCanceled => _isCanceled;
+
+    private Task StartBackgroundRefresh()
+    {
+        if (_isCompleted)
+            return Task.CompletedTask;
+        return Task.Run(async () =>
+        {
+            while (!_isCompleted && !_cts.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(ExportClient.Config.PollInterval, _cts.Token);
+                    await RefreshStatusInternal();
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch { }
+            }
+        });
+    }
+
+    private async Task RefreshStatusInternal(CancellationToken cancellationToken = default)
+    {
+        if (_isCompleted)
+            return;
+        var status = await _statusFetcher(
+            cancellationToken == default ? _cts.Token : cancellationToken
+        );
+        _current = status;
+        if (IsTerminalStatus(status.Status))
+        {
+            _isCompleted = true;
+            _isSuccessful = status.Status == ExportStatus.Success;
+            _isCanceled = status.Status == ExportStatus.Canceled;
+            await _cts.CancelAsync();
+            DisposeInternal();
+        }
+    }
+
+    /// <summary>
+    /// Waits asynchronously for the export operation to complete or timeout.
+    /// </summary>
+    /// <param name="timeout">Optional timeout for the operation. If not specified, uses the default export timeout.</param>
+    /// <param name="cancellationToken">A cancellation token to observe while waiting.</param>
+    /// <returns>The final <see cref="Export"/> result.</returns>
+    public async Task<Export> WaitForCompletion(
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var effectiveTimeout = timeout ?? ExportClient.Config.Timeout;
+        var start = DateTime.UtcNow;
+
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            _cts.Token,
+            cancellationToken
+        );
+        var effectiveToken = linkedCts.Token;
+
+        while (!_isCompleted && !effectiveToken.IsCancellationRequested)
+        {
+            if (DateTime.UtcNow - start > effectiveTimeout)
+            {
+                throw new TimeoutException(
+                    $"Export operation did not complete within {effectiveTimeout} (last status={_current.Status})."
+                );
+            }
+            try
+            {
+                await Task.Delay(ExportClient.Config.PollInterval, effectiveToken);
+            }
+            catch (OperationCanceledException) when (_isCompleted) { }
+        }
+        return _current;
+    }
+
+    /// <summary>
+    /// Cancels the export operation asynchronously.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token to observe while canceling.</param>
+    public async Task Cancel(CancellationToken cancellationToken = default)
+    {
+        await _operationCancel(cancellationToken);
+        await RefreshStatusInternal(cancellationToken);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+            return;
+        if (disposing)
+        {
+            _cts.Cancel();
+            try
+            {
+                _backgroundRefreshTask.Wait(ExportClient.Config.PollInterval);
+            }
+            catch (Exception) { }
+            _cts.Dispose();
+        }
+        _disposed = true;
+    }
+
+    private void DisposeInternal()
+    {
+        if (_disposed)
+            return;
+        try
+        {
+            _backgroundRefreshTask.Wait(ExportClient.Config.PollInterval);
+        }
+        catch (Exception)
+        {
+            // Best-effort disposal
+        }
+        _cts.Dispose();
+        _disposed = true;
+    }
+
+    /// <summary>
+    /// Disposes the export operation and releases resources.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+    }
+
+    /// <summary>
+    /// Disposes the export operation asynchronously and releases resources.
+    /// </summary>
+    /// <returns>A <see cref="ValueTask"/> representing the asynchronous dispose operation.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+        _cts.Cancel();
+        try
+        {
+            await _backgroundRefreshTask.ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Best-effort disposal
+        }
+        _cts.Dispose();
+        _disposed = true;
+        GC.SuppressFinalize(this);
+    }
+
+    private static bool IsTerminalStatus(ExportStatus? status)
+    {
+        return status == ExportStatus.Success
+            || status == ExportStatus.Failed
+            || status == ExportStatus.Canceled;
+    }
+}

--- a/src/Weaviate.Client/Models/ExportOperationBase.cs
+++ b/src/Weaviate.Client/Models/ExportOperationBase.cs
@@ -6,7 +6,7 @@ namespace Weaviate.Client.Models;
 public abstract class ExportOperationBase : IDisposable, IAsyncDisposable
 {
     private readonly Func<CancellationToken, Task<Export>> _statusFetcher;
-    private readonly Func<CancellationToken, Task> _operationCancel;
+    private readonly Func<CancellationToken, Task<bool>> _operationCancel;
     private readonly CancellationTokenSource _cts = new();
     private readonly Task _backgroundRefreshTask;
     private Export _current;
@@ -24,7 +24,7 @@ public abstract class ExportOperationBase : IDisposable, IAsyncDisposable
     protected ExportOperationBase(
         Export initial,
         Func<CancellationToken, Task<Export>> statusFetcher,
-        Func<CancellationToken, Task> operationCancel
+        Func<CancellationToken, Task<bool>> operationCancel
     )
     {
         _current = initial;
@@ -134,13 +134,16 @@ public abstract class ExportOperationBase : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// Cancels the export operation asynchronously.
+    /// Cancels the export operation asynchronously. Returns <c>true</c> if the server
+    /// accepted the cancel request, <c>false</c> if the export is already in a terminal
+    /// state and cannot be canceled (HTTP 409). Throws if the export id is unknown.
     /// </summary>
     /// <param name="cancellationToken">A cancellation token to observe while canceling.</param>
-    public async Task Cancel(CancellationToken cancellationToken = default)
+    public async Task<bool> Cancel(CancellationToken cancellationToken = default)
     {
-        await _operationCancel(cancellationToken);
+        var canceled = await _operationCancel(cancellationToken);
         await RefreshStatusInternal(cancellationToken);
+        return canceled;
     }
 
     protected virtual void Dispose(bool disposing)

--- a/src/Weaviate.Client/Models/ExportOperationBase.cs
+++ b/src/Weaviate.Client/Models/ExportOperationBase.cs
@@ -1,7 +1,7 @@
 namespace Weaviate.Client.Models;
 
 /// <summary>
-/// Abstract base for export operations, with status polling and cancellation.
+/// Abstract base class for export operations, providing status polling, cancellation, and resource management.
 /// </summary>
 public abstract class ExportOperationBase : IDisposable, IAsyncDisposable
 {
@@ -15,6 +15,12 @@ public abstract class ExportOperationBase : IDisposable, IAsyncDisposable
     private volatile bool _isCanceled;
     private bool _disposed;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExportOperationBase"/> class.
+    /// </summary>
+    /// <param name="initial">The initial export state.</param>
+    /// <param name="statusFetcher">A delegate to fetch the latest export status.</param>
+    /// <param name="operationCancel">A delegate to cancel the export operation.</param>
     protected ExportOperationBase(
         Export initial,
         Func<CancellationToken, Task<Export>> statusFetcher,

--- a/src/Weaviate.Client/Models/StorageBackend.cs
+++ b/src/Weaviate.Client/Models/StorageBackend.cs
@@ -1,0 +1,23 @@
+namespace Weaviate.Client.Models;
+
+/// <summary>
+/// Shared base for storage backend configurations used by Weaviate sub-clients that
+/// persist data to external storage (backup, export, …). Concrete subtypes
+/// (<see cref="FilesystemBackend"/>, <see cref="ObjectStorageBackend"/>, …) describe a
+/// specific storage location; the per-feature abstract types <see cref="BackupBackend"/>
+/// and <see cref="ExportBackend"/> serve as discoverable factory namespaces with
+/// feature-appropriate naming, and inherit from this type so the same concrete instances
+/// can be passed to either feature's API.
+/// </summary>
+public abstract record StorageBackend
+{
+    /// <summary>
+    /// The backend storage provider (filesystem, S3, GCS, Azure, …).
+    /// </summary>
+    public abstract BackupStorageProvider Provider { get; }
+
+    /// <summary>
+    /// Optional path within the storage location.
+    /// </summary>
+    public abstract string? Path { get; }
+}

--- a/src/Weaviate.Client/PublicAPI.Unshipped.txt
+++ b/src/Weaviate.Client/PublicAPI.Unshipped.txt
@@ -424,11 +424,31 @@ override Weaviate.Client.Models.DatabaseUser.ToString() -> string!
 override Weaviate.Client.Models.DataReference.Equals(object? obj) -> bool
 override Weaviate.Client.Models.DataReference.GetHashCode() -> int
 override Weaviate.Client.Models.DataReference.ToString() -> string!
+Weaviate.Client.Models.DataReference
+Weaviate.Client.Models.DataReference.DataReference(System.Guid From, string! FromProperty, System.Collections.Generic.IEnumerable<System.Guid>! To) -> void
+Weaviate.Client.Models.DataReference.DataReference(System.Guid from, string! fromProperty, params System.Guid[]! to) -> void
+Weaviate.Client.Models.DataReference.DataReference(Weaviate.Client.Models.DataReference! original) -> void
+Weaviate.Client.Models.DataReference.Deconstruct(out System.Guid From, out string! FromProperty, out System.Collections.Generic.IEnumerable<System.Guid>! To) -> void
+Weaviate.Client.Models.DataReference.From.get -> System.Guid
+Weaviate.Client.Models.DataReference.From.init -> void
+Weaviate.Client.Models.DataReference.FromProperty.get -> string!
+Weaviate.Client.Models.DataReference.FromProperty.init -> void
+Weaviate.Client.Models.DataReference.To.get -> System.Collections.Generic.IEnumerable<System.Guid>!
+Weaviate.Client.Models.DataReference.To.init -> void
 override Weaviate.Client.Models.DataResource.Equals(object? obj) -> bool
 override Weaviate.Client.Models.DataResource.GetHashCode() -> int
 override Weaviate.Client.Models.DataResource.ToString() -> string!
 override Weaviate.Client.Models.EmptyStringEnumConverter<T>.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> T
 override Weaviate.Client.Models.EmptyStringEnumConverter<T>.Write(System.Text.Json.Utf8JsonWriter! writer, T value, System.Text.Json.JsonSerializerOptions! options) -> void
+override Weaviate.Client.Models.Export.Equals(object? obj) -> bool
+override Weaviate.Client.Models.Export.GetHashCode() -> int
+override Weaviate.Client.Models.Export.ToString() -> string!
+override Weaviate.Client.Models.ExportClientConfig.Equals(object? obj) -> bool
+override Weaviate.Client.Models.ExportClientConfig.GetHashCode() -> int
+override Weaviate.Client.Models.ExportClientConfig.ToString() -> string!
+override Weaviate.Client.Models.ExportCreateRequest.Equals(object? obj) -> bool
+override Weaviate.Client.Models.ExportCreateRequest.GetHashCode() -> int
+override Weaviate.Client.Models.ExportCreateRequest.ToString() -> string!
 override Weaviate.Client.Models.FilesystemBackend.<Clone>$() -> Weaviate.Client.Models.FilesystemBackend!
 override Weaviate.Client.Models.FilesystemBackend.EqualityContract.get -> System.Type!
 override Weaviate.Client.Models.FilesystemBackend.Equals(object? obj) -> bool
@@ -674,6 +694,8 @@ override Weaviate.Client.Models.GroupByResult.ToString() -> string!
 override Weaviate.Client.Models.GroupByResult<TObject, TGroup>.Equals(object? obj) -> bool
 override Weaviate.Client.Models.GroupByResult<TObject, TGroup>.GetHashCode() -> int
 override Weaviate.Client.Models.GroupByResult<TObject, TGroup>.ToString() -> string!
+Weaviate.Client.Models.GroupByResult<TObject, TGroup>.QueryProfile.get -> Weaviate.Client.Models.QueryProfile?
+Weaviate.Client.Models.GroupByResult<TObject, TGroup>.QueryProfile.init -> void
 override Weaviate.Client.Models.GroupedTask.<Clone>$() -> Weaviate.Client.Models.GroupedTask!
 override Weaviate.Client.Models.GroupedTask.EqualityContract.get -> System.Type!
 override Weaviate.Client.Models.GroupedTask.Equals(object? obj) -> bool
@@ -839,6 +861,9 @@ override Weaviate.Client.Models.ShardInfo.ToString() -> string!
 override Weaviate.Client.Models.ShardingConfig.Equals(object? obj) -> bool
 override Weaviate.Client.Models.ShardingConfig.GetHashCode() -> int
 override Weaviate.Client.Models.ShardingConfig.ToString() -> string!
+override Weaviate.Client.Models.ShardProgress.Equals(object? obj) -> bool
+override Weaviate.Client.Models.ShardProgress.GetHashCode() -> int
+override Weaviate.Client.Models.ShardProgress.ToString() -> string!
 override Weaviate.Client.Models.SimpleTargetVectors.<Clone>$() -> Weaviate.Client.Models.SimpleTargetVectors!
 override Weaviate.Client.Models.SimpleTargetVectors.Equals(object? obj) -> bool
 override Weaviate.Client.Models.SimpleTargetVectors.GetHashCode() -> int
@@ -1250,6 +1275,8 @@ override Weaviate.Client.Models.WeaviateResult.ToString() -> string!
 override Weaviate.Client.Models.WeaviateResult<TObject>.Equals(object? obj) -> bool
 override Weaviate.Client.Models.WeaviateResult<TObject>.GetHashCode() -> int
 override Weaviate.Client.Models.WeaviateResult<TObject>.ToString() -> string!
+Weaviate.Client.Models.WeaviateResult<TObject>.QueryProfile.get -> Weaviate.Client.Models.QueryProfile?
+Weaviate.Client.Models.WeaviateResult<TObject>.QueryProfile.init -> void
 override Weaviate.Client.Models.WeightedField.Equals(object? obj) -> bool
 override Weaviate.Client.Models.WeightedField.GetHashCode() -> int
 override Weaviate.Client.Models.WeightedField.ToString() -> string!
@@ -1304,6 +1331,8 @@ static Weaviate.Client.Connect.Cloud(string! restEndpoint, string? apiKey = null
 static Weaviate.Client.Connect.FromEnvironment(string! prefix = "WEAVIATE_", System.TimeSpan? defaultTimeout = null, System.TimeSpan? initTimeout = null, System.TimeSpan? insertTimeout = null, System.TimeSpan? queryTimeout = null) -> System.Threading.Tasks.Task<Weaviate.Client.WeaviateClient!>!
 static Weaviate.Client.Connect.Local(Weaviate.Client.Auth.ApiKeyCredentials! credentials, string! hostname = "localhost", ushort restPort = 8080, ushort grpcPort = 50051, bool useSsl = false, System.Collections.Generic.Dictionary<string!, string!>? headers = null, System.Net.Http.HttpMessageHandler? httpMessageHandler = null, System.TimeSpan? defaultTimeout = null, System.TimeSpan? initTimeout = null, System.TimeSpan? insertTimeout = null, System.TimeSpan? queryTimeout = null) -> System.Threading.Tasks.Task<Weaviate.Client.WeaviateClient!>!
 static Weaviate.Client.Connect.Local(Weaviate.Client.ICredentials? credentials = null, string! hostname = "localhost", ushort restPort = 8080, ushort grpcPort = 50051, bool useSsl = false, System.Collections.Generic.Dictionary<string!, string!>? headers = null, System.Net.Http.HttpMessageHandler? httpMessageHandler = null, System.TimeSpan? defaultTimeout = null, System.TimeSpan? initTimeout = null, System.TimeSpan? insertTimeout = null, System.TimeSpan? queryTimeout = null) -> System.Threading.Tasks.Task<Weaviate.Client.WeaviateClient!>!
+static Weaviate.Client.ExportClient.Config.get -> Weaviate.Client.Models.ExportClientConfig!
+static Weaviate.Client.ExportClient.Config.set -> void
 static Weaviate.Client.DependencyInjection.WeaviateServiceCollectionExtensions.AddWeaviate(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, Microsoft.Extensions.Configuration.IConfiguration! configuration, bool eagerInitialization = true) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Weaviate.Client.DependencyInjection.WeaviateServiceCollectionExtensions.AddWeaviate(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Weaviate.Client.DependencyInjection.WeaviateOptions!>! configureOptions, bool eagerInitialization = true) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Weaviate.Client.DependencyInjection.WeaviateServiceCollectionExtensions.AddWeaviateClient(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, string! name, System.Action<Weaviate.Client.DependencyInjection.WeaviateOptions!>! configureOptions) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
@@ -1440,6 +1469,14 @@ static Weaviate.Client.Models.DataReference.operator !=(Weaviate.Client.Models.D
 static Weaviate.Client.Models.DataReference.operator ==(Weaviate.Client.Models.DataReference? left, Weaviate.Client.Models.DataReference? right) -> bool
 static Weaviate.Client.Models.DataResource.operator !=(Weaviate.Client.Models.DataResource? left, Weaviate.Client.Models.DataResource? right) -> bool
 static Weaviate.Client.Models.DataResource.operator ==(Weaviate.Client.Models.DataResource? left, Weaviate.Client.Models.DataResource? right) -> bool
+static Weaviate.Client.Models.Export.operator !=(Weaviate.Client.Models.Export? left, Weaviate.Client.Models.Export? right) -> bool
+static Weaviate.Client.Models.Export.operator ==(Weaviate.Client.Models.Export? left, Weaviate.Client.Models.Export? right) -> bool
+static Weaviate.Client.Models.ExportClientConfig.Default.get -> Weaviate.Client.Models.ExportClientConfig!
+static Weaviate.Client.Models.ExportClientConfig.operator !=(Weaviate.Client.Models.ExportClientConfig? left, Weaviate.Client.Models.ExportClientConfig? right) -> bool
+static Weaviate.Client.Models.ExportClientConfig.operator ==(Weaviate.Client.Models.ExportClientConfig? left, Weaviate.Client.Models.ExportClientConfig? right) -> bool
+static Weaviate.Client.Models.ExportCreateRequest.operator !=(Weaviate.Client.Models.ExportCreateRequest? left, Weaviate.Client.Models.ExportCreateRequest? right) -> bool
+static Weaviate.Client.Models.ExportCreateRequest.operator ==(Weaviate.Client.Models.ExportCreateRequest? left, Weaviate.Client.Models.ExportCreateRequest? right) -> bool
+static Weaviate.Client.Models.ExportStatusExtensions.ToExportStatus(this string? status) -> Weaviate.Client.Models.ExportStatus
 static Weaviate.Client.Models.FilesystemBackend.operator !=(Weaviate.Client.Models.FilesystemBackend? left, Weaviate.Client.Models.FilesystemBackend? right) -> bool
 static Weaviate.Client.Models.FilesystemBackend.operator ==(Weaviate.Client.Models.FilesystemBackend? left, Weaviate.Client.Models.FilesystemBackend? right) -> bool
 static Weaviate.Client.Models.Filter.AllOf(params Weaviate.Client.Models.Filter![]! filters) -> Weaviate.Client.Models.Filter!
@@ -1714,6 +1751,8 @@ static Weaviate.Client.Models.ShardingConfig.Default.get -> Weaviate.Client.Mode
 static Weaviate.Client.Models.ShardingConfig.operator !=(Weaviate.Client.Models.ShardingConfig? left, Weaviate.Client.Models.ShardingConfig? right) -> bool
 static Weaviate.Client.Models.ShardingConfig.operator ==(Weaviate.Client.Models.ShardingConfig? left, Weaviate.Client.Models.ShardingConfig? right) -> bool
 static Weaviate.Client.Models.ShardingConfig.Zero.get -> Weaviate.Client.Models.ShardingConfig!
+static Weaviate.Client.Models.ShardProgress.operator !=(Weaviate.Client.Models.ShardProgress? left, Weaviate.Client.Models.ShardProgress? right) -> bool
+static Weaviate.Client.Models.ShardProgress.operator ==(Weaviate.Client.Models.ShardProgress? left, Weaviate.Client.Models.ShardProgress? right) -> bool
 static Weaviate.Client.Models.SimpleTargetVectors.operator !=(Weaviate.Client.Models.SimpleTargetVectors? left, Weaviate.Client.Models.SimpleTargetVectors? right) -> bool
 static Weaviate.Client.Models.SimpleTargetVectors.operator ==(Weaviate.Client.Models.SimpleTargetVectors? left, Weaviate.Client.Models.SimpleTargetVectors? right) -> bool
 static Weaviate.Client.Models.SinglePrompt.implicit operator Weaviate.Client.Models.SinglePrompt!(string! prompt) -> Weaviate.Client.Models.SinglePrompt!
@@ -2201,6 +2240,19 @@ virtual Weaviate.Client.Models.DataResource.<Clone>$() -> Weaviate.Client.Models
 virtual Weaviate.Client.Models.DataResource.EqualityContract.get -> System.Type!
 virtual Weaviate.Client.Models.DataResource.Equals(Weaviate.Client.Models.DataResource? other) -> bool
 virtual Weaviate.Client.Models.DataResource.PrintMembers(System.Text.StringBuilder! builder) -> bool
+virtual Weaviate.Client.Models.Export.<Clone>$() -> Weaviate.Client.Models.Export!
+virtual Weaviate.Client.Models.Export.EqualityContract.get -> System.Type!
+virtual Weaviate.Client.Models.Export.Equals(Weaviate.Client.Models.Export? other) -> bool
+virtual Weaviate.Client.Models.Export.PrintMembers(System.Text.StringBuilder! builder) -> bool
+virtual Weaviate.Client.Models.ExportClientConfig.<Clone>$() -> Weaviate.Client.Models.ExportClientConfig!
+virtual Weaviate.Client.Models.ExportClientConfig.EqualityContract.get -> System.Type!
+virtual Weaviate.Client.Models.ExportClientConfig.Equals(Weaviate.Client.Models.ExportClientConfig? other) -> bool
+virtual Weaviate.Client.Models.ExportClientConfig.PrintMembers(System.Text.StringBuilder! builder) -> bool
+virtual Weaviate.Client.Models.ExportCreateRequest.<Clone>$() -> Weaviate.Client.Models.ExportCreateRequest!
+virtual Weaviate.Client.Models.ExportCreateRequest.EqualityContract.get -> System.Type!
+virtual Weaviate.Client.Models.ExportCreateRequest.Equals(Weaviate.Client.Models.ExportCreateRequest? other) -> bool
+virtual Weaviate.Client.Models.ExportCreateRequest.PrintMembers(System.Text.StringBuilder! builder) -> bool
+virtual Weaviate.Client.Models.ExportOperationBase.Dispose(bool disposing) -> void
 virtual Weaviate.Client.Models.FilesystemBackend.Equals(Weaviate.Client.Models.FilesystemBackend? other) -> bool
 virtual Weaviate.Client.Models.Filter.<Clone>$() -> Weaviate.Client.Models.Filter!
 virtual Weaviate.Client.Models.Filter.EqualityContract.get -> System.Type!
@@ -2494,6 +2546,10 @@ virtual Weaviate.Client.Models.ShardingConfig.<Clone>$() -> Weaviate.Client.Mode
 virtual Weaviate.Client.Models.ShardingConfig.EqualityContract.get -> System.Type!
 virtual Weaviate.Client.Models.ShardingConfig.Equals(Weaviate.Client.Models.ShardingConfig? other) -> bool
 virtual Weaviate.Client.Models.ShardingConfig.PrintMembers(System.Text.StringBuilder! builder) -> bool
+virtual Weaviate.Client.Models.ShardProgress.<Clone>$() -> Weaviate.Client.Models.ShardProgress!
+virtual Weaviate.Client.Models.ShardProgress.EqualityContract.get -> System.Type!
+virtual Weaviate.Client.Models.ShardProgress.Equals(Weaviate.Client.Models.ShardProgress? other) -> bool
+virtual Weaviate.Client.Models.ShardProgress.PrintMembers(System.Text.StringBuilder! builder) -> bool
 virtual Weaviate.Client.Models.SinglePrompt.Equals(Weaviate.Client.Models.SinglePrompt? other) -> bool
 virtual Weaviate.Client.Models.Sort.<Clone>$() -> Weaviate.Client.Models.Sort!
 virtual Weaviate.Client.Models.Sort.EqualityContract.get -> System.Type!
@@ -2879,6 +2935,11 @@ Weaviate.Client.DefaultTokenServiceFactory
 Weaviate.Client.DefaultTokenServiceFactory.CreateAsync(Weaviate.Client.ClientConfiguration! configuration) -> System.Threading.Tasks.Task<Weaviate.Client.ITokenService?>!
 Weaviate.Client.DefaultTokenServiceFactory.CreateSync(Weaviate.Client.ClientConfiguration! configuration) -> Weaviate.Client.ITokenService?
 Weaviate.Client.DefaultTokenServiceFactory.DefaultTokenServiceFactory() -> void
+Weaviate.Client.ExportClient
+Weaviate.Client.ExportClient.Cancel(Weaviate.Client.Models.BackupBackend! backend, string! id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Weaviate.Client.ExportClient.Create(Weaviate.Client.Models.ExportCreateRequest! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.Models.ExportOperation!>!
+Weaviate.Client.ExportClient.CreateSync(Weaviate.Client.Models.ExportCreateRequest! request, System.TimeSpan? timeout = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.Models.Export!>!
+Weaviate.Client.ExportClient.GetStatus(Weaviate.Client.Models.BackupBackend! backend, string! id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.Models.Export!>!
 Weaviate.Client.DependencyInjection.IWeaviateClientFactory
 Weaviate.Client.DependencyInjection.IWeaviateClientFactory.GetClient(string! name) -> Weaviate.Client.WeaviateClient!
 Weaviate.Client.DependencyInjection.IWeaviateClientFactory.GetClientAsync(string! name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.WeaviateClient!>!
@@ -3641,6 +3702,73 @@ Weaviate.Client.Models.DeletionStrategy.NoAutomatedResolution = 0 -> Weaviate.Cl
 Weaviate.Client.Models.DeletionStrategy.TimeBasedResolution = 2 -> Weaviate.Client.Models.DeletionStrategy
 Weaviate.Client.Models.EmptyStringEnumConverter<T>
 Weaviate.Client.Models.EmptyStringEnumConverter<T>.EmptyStringEnumConverter() -> void
+Weaviate.Client.Models.Export
+Weaviate.Client.Models.Export.Backend.get -> Weaviate.Client.Models.BackupBackend!
+Weaviate.Client.Models.Export.Backend.init -> void
+Weaviate.Client.Models.Export.Collections.get -> string![]?
+Weaviate.Client.Models.Export.Collections.init -> void
+Weaviate.Client.Models.Export.CompletedAt.get -> System.DateTimeOffset?
+Weaviate.Client.Models.Export.CompletedAt.init -> void
+Weaviate.Client.Models.Export.Deconstruct(out string! Id, out Weaviate.Client.Models.BackupBackend! Backend, out string? Path, out string! StatusRaw, out string![]? Collections, out System.DateTimeOffset? StartedAt, out System.DateTimeOffset? CompletedAt, out string? Error) -> void
+Weaviate.Client.Models.Export.Error.get -> string?
+Weaviate.Client.Models.Export.Error.init -> void
+Weaviate.Client.Models.Export.Export(Weaviate.Client.Models.Export! original) -> void
+Weaviate.Client.Models.Export.Export(string! Id, Weaviate.Client.Models.BackupBackend! Backend, string? Path, string! StatusRaw, string![]? Collections, System.DateTimeOffset? StartedAt, System.DateTimeOffset? CompletedAt, string? Error) -> void
+Weaviate.Client.Models.Export.Path.get -> string?
+Weaviate.Client.Models.Export.Path.init -> void
+Weaviate.Client.Models.Export.Id.get -> string!
+Weaviate.Client.Models.Export.Id.init -> void
+Weaviate.Client.Models.Export.ShardStatus.get -> System.Collections.Generic.Dictionary<string!, System.Collections.Generic.Dictionary<string!, Weaviate.Client.Models.ShardProgress!>!>?
+Weaviate.Client.Models.Export.ShardStatus.init -> void
+Weaviate.Client.Models.Export.StartedAt.get -> System.DateTimeOffset?
+Weaviate.Client.Models.Export.StartedAt.init -> void
+Weaviate.Client.Models.Export.Status.get -> Weaviate.Client.Models.ExportStatus
+Weaviate.Client.Models.Export.StatusRaw.get -> string!
+Weaviate.Client.Models.Export.StatusRaw.init -> void
+Weaviate.Client.Models.Export.TookInMs.get -> int?
+Weaviate.Client.Models.Export.TookInMs.init -> void
+Weaviate.Client.Models.ExportClientConfig
+Weaviate.Client.Models.ExportClientConfig.ExportClientConfig() -> void
+Weaviate.Client.Models.ExportClientConfig.ExportClientConfig(Weaviate.Client.Models.ExportClientConfig! original) -> void
+Weaviate.Client.Models.ExportClientConfig.PollInterval.get -> System.TimeSpan
+Weaviate.Client.Models.ExportClientConfig.PollInterval.init -> void
+Weaviate.Client.Models.ExportClientConfig.Timeout.get -> System.TimeSpan
+Weaviate.Client.Models.ExportClientConfig.Timeout.init -> void
+Weaviate.Client.Models.ExportCreateRequest
+Weaviate.Client.Models.ExportCreateRequest.Backend.get -> Weaviate.Client.Models.BackupBackend!
+Weaviate.Client.Models.ExportCreateRequest.Backend.init -> void
+Weaviate.Client.Models.ExportCreateRequest.Deconstruct(out string! Id, out Weaviate.Client.Models.BackupBackend! Backend, out Weaviate.Client.Models.ExportFileFormat FileFormat, out Weaviate.Client.Internal.AutoArray<string!>? IncludeCollections, out Weaviate.Client.Internal.AutoArray<string!>? ExcludeCollections) -> void
+Weaviate.Client.Models.ExportCreateRequest.ExcludeCollections.get -> Weaviate.Client.Internal.AutoArray<string!>?
+Weaviate.Client.Models.ExportCreateRequest.ExcludeCollections.init -> void
+Weaviate.Client.Models.ExportCreateRequest.ExportCreateRequest(Weaviate.Client.Models.ExportCreateRequest! original) -> void
+Weaviate.Client.Models.ExportCreateRequest.ExportCreateRequest(string! Id, Weaviate.Client.Models.BackupBackend! Backend, Weaviate.Client.Models.ExportFileFormat FileFormat = Weaviate.Client.Models.ExportFileFormat.Parquet, Weaviate.Client.Internal.AutoArray<string!>? IncludeCollections = null, Weaviate.Client.Internal.AutoArray<string!>? ExcludeCollections = null) -> void
+Weaviate.Client.Models.ExportCreateRequest.FileFormat.get -> Weaviate.Client.Models.ExportFileFormat
+Weaviate.Client.Models.ExportCreateRequest.FileFormat.init -> void
+Weaviate.Client.Models.ExportCreateRequest.Id.get -> string!
+Weaviate.Client.Models.ExportCreateRequest.Id.init -> void
+Weaviate.Client.Models.ExportCreateRequest.IncludeCollections.get -> Weaviate.Client.Internal.AutoArray<string!>?
+Weaviate.Client.Models.ExportCreateRequest.IncludeCollections.init -> void
+Weaviate.Client.Models.ExportFileFormat
+Weaviate.Client.Models.ExportFileFormat.Parquet = 0 -> Weaviate.Client.Models.ExportFileFormat
+Weaviate.Client.Models.ExportOperation
+Weaviate.Client.Models.ExportOperationBase
+Weaviate.Client.Models.ExportOperationBase.Cancel(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Weaviate.Client.Models.ExportOperationBase.Current.get -> Weaviate.Client.Models.Export!
+Weaviate.Client.Models.ExportOperationBase.Dispose() -> void
+Weaviate.Client.Models.ExportOperationBase.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Weaviate.Client.Models.ExportOperationBase.ExportOperationBase(Weaviate.Client.Models.Export! initial, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<Weaviate.Client.Models.Export!>!>! statusFetcher, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! operationCancel) -> void
+Weaviate.Client.Models.ExportOperationBase.IsCanceled.get -> bool
+Weaviate.Client.Models.ExportOperationBase.IsCompleted.get -> bool
+Weaviate.Client.Models.ExportOperationBase.IsSuccessful.get -> bool
+Weaviate.Client.Models.ExportOperationBase.WaitForCompletion(System.TimeSpan? timeout = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.Models.Export!>!
+Weaviate.Client.Models.ExportStatus
+Weaviate.Client.Models.ExportStatus.Canceled = 5 -> Weaviate.Client.Models.ExportStatus
+Weaviate.Client.Models.ExportStatus.Failed = 4 -> Weaviate.Client.Models.ExportStatus
+Weaviate.Client.Models.ExportStatus.Started = 1 -> Weaviate.Client.Models.ExportStatus
+Weaviate.Client.Models.ExportStatus.Success = 3 -> Weaviate.Client.Models.ExportStatus
+Weaviate.Client.Models.ExportStatus.Transferring = 2 -> Weaviate.Client.Models.ExportStatus
+Weaviate.Client.Models.ExportStatus.Unknown = 0 -> Weaviate.Client.Models.ExportStatus
+Weaviate.Client.Models.ExportStatusExtensions
 Weaviate.Client.Models.FilesystemBackend
 Weaviate.Client.Models.FilesystemBackend.FilesystemBackend(string? path = null) -> void
 Weaviate.Client.Models.FilesystemBackend.FilesystemBackend(Weaviate.Client.Models.FilesystemBackend! original) -> void
@@ -5154,6 +5282,18 @@ Weaviate.Client.Models.ShardingConfig.Strategy.get -> Weaviate.Client.Models.Sha
 Weaviate.Client.Models.ShardingConfig.Strategy.set -> void
 Weaviate.Client.Models.ShardingConfig.VirtualPerPhysical.get -> int
 Weaviate.Client.Models.ShardingConfig.VirtualPerPhysical.set -> void
+Weaviate.Client.Models.ShardProgress
+Weaviate.Client.Models.ShardProgress.Deconstruct(out string! StatusRaw, out int ObjectsExported, out string? Error, out string? SkipReason) -> void
+Weaviate.Client.Models.ShardProgress.Error.get -> string?
+Weaviate.Client.Models.ShardProgress.Error.init -> void
+Weaviate.Client.Models.ShardProgress.ObjectsExported.get -> int
+Weaviate.Client.Models.ShardProgress.ObjectsExported.init -> void
+Weaviate.Client.Models.ShardProgress.ShardProgress(Weaviate.Client.Models.ShardProgress! original) -> void
+Weaviate.Client.Models.ShardProgress.ShardProgress(string! StatusRaw, int ObjectsExported, string? Error, string? SkipReason) -> void
+Weaviate.Client.Models.ShardProgress.SkipReason.get -> string?
+Weaviate.Client.Models.ShardProgress.SkipReason.init -> void
+Weaviate.Client.Models.ShardProgress.StatusRaw.get -> string!
+Weaviate.Client.Models.ShardProgress.StatusRaw.init -> void
 Weaviate.Client.Models.ShardStatus
 Weaviate.Client.Models.ShardStatus.Indexing = 2 -> Weaviate.Client.Models.ShardStatus
 Weaviate.Client.Models.ShardStatus.ReadOnly = 1 -> Weaviate.Client.Models.ShardStatus
@@ -6233,15 +6373,16 @@ Weaviate.Client.ResourceType
 Weaviate.Client.ResourceType.Alias = 0 -> Weaviate.Client.ResourceType
 Weaviate.Client.ResourceType.Backup = Weaviate.Client.ResourceType.Object | Weaviate.Client.ResourceType.User -> Weaviate.Client.ResourceType
 Weaviate.Client.ResourceType.Collection = 1 -> Weaviate.Client.ResourceType
-Weaviate.Client.ResourceType.Group = Weaviate.Client.ResourceType.Collection | Weaviate.Client.ResourceType.Backup -> Weaviate.Client.ResourceType
+Weaviate.Client.ResourceType.Export = Weaviate.Client.ResourceType.Collection | Weaviate.Client.ResourceType.Backup -> Weaviate.Client.ResourceType
+Weaviate.Client.ResourceType.Group = 8 -> Weaviate.Client.ResourceType
 Weaviate.Client.ResourceType.Object = 2 -> Weaviate.Client.ResourceType
 Weaviate.Client.ResourceType.Property = Weaviate.Client.ResourceType.Collection | Weaviate.Client.ResourceType.Object -> Weaviate.Client.ResourceType
-Weaviate.Client.ResourceType.Reference = 8 -> Weaviate.Client.ResourceType
-Weaviate.Client.ResourceType.Replication = Weaviate.Client.ResourceType.Collection | Weaviate.Client.ResourceType.Tenant -> Weaviate.Client.ResourceType
+Weaviate.Client.ResourceType.Reference = Weaviate.Client.ResourceType.Collection | Weaviate.Client.ResourceType.Group -> Weaviate.Client.ResourceType
+Weaviate.Client.ResourceType.Replication = Weaviate.Client.ResourceType.User | Weaviate.Client.ResourceType.Group -> Weaviate.Client.ResourceType
 Weaviate.Client.ResourceType.Role = Weaviate.Client.ResourceType.Collection | Weaviate.Client.ResourceType.User -> Weaviate.Client.ResourceType
-Weaviate.Client.ResourceType.Shard = Weaviate.Client.ResourceType.Collection | Weaviate.Client.ResourceType.Reference -> Weaviate.Client.ResourceType
-Weaviate.Client.ResourceType.Tenant = Weaviate.Client.ResourceType.Object | Weaviate.Client.ResourceType.Reference -> Weaviate.Client.ResourceType
-Weaviate.Client.ResourceType.Unknown = Weaviate.Client.ResourceType.User | Weaviate.Client.ResourceType.Reference -> Weaviate.Client.ResourceType
+Weaviate.Client.ResourceType.Shard = Weaviate.Client.ResourceType.Object | Weaviate.Client.ResourceType.Group -> Weaviate.Client.ResourceType
+Weaviate.Client.ResourceType.Tenant = Weaviate.Client.ResourceType.Collection | Weaviate.Client.ResourceType.Shard -> Weaviate.Client.ResourceType
+Weaviate.Client.ResourceType.Unknown = Weaviate.Client.ResourceType.Collection | Weaviate.Client.ResourceType.Replication -> Weaviate.Client.ResourceType
 Weaviate.Client.ResourceType.User = 4 -> Weaviate.Client.ResourceType
 Weaviate.Client.RetryOn
 Weaviate.Client.RetryOn.NetworkError = 8 -> Weaviate.Client.RetryOn
@@ -6542,6 +6683,7 @@ Weaviate.Client.WeaviateClient.Cluster.get -> Weaviate.Client.ClusterClient!
 Weaviate.Client.WeaviateClient.Collections.get -> Weaviate.Client.CollectionsClient!
 Weaviate.Client.WeaviateClient.Configuration.get -> Weaviate.Client.ClientConfiguration!
 Weaviate.Client.WeaviateClient.Dispose() -> void
+Weaviate.Client.WeaviateClient.Export.get -> Weaviate.Client.ExportClient!
 Weaviate.Client.WeaviateClient.GetMeta(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.Models.MetaInfo>!
 Weaviate.Client.WeaviateClient.Groups.get -> Weaviate.Client.GroupsClient!
 Weaviate.Client.WeaviateClient.InitializeAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/Weaviate.Client/PublicAPI.Unshipped.txt
+++ b/src/Weaviate.Client/PublicAPI.Unshipped.txt
@@ -2936,7 +2936,7 @@ Weaviate.Client.DefaultTokenServiceFactory.CreateAsync(Weaviate.Client.ClientCon
 Weaviate.Client.DefaultTokenServiceFactory.CreateSync(Weaviate.Client.ClientConfiguration! configuration) -> Weaviate.Client.ITokenService?
 Weaviate.Client.DefaultTokenServiceFactory.DefaultTokenServiceFactory() -> void
 Weaviate.Client.ExportClient
-Weaviate.Client.ExportClient.Cancel(Weaviate.Client.Models.BackupBackend! backend, string! id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Weaviate.Client.ExportClient.Cancel(Weaviate.Client.Models.BackupBackend! backend, string! id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
 Weaviate.Client.ExportClient.Create(Weaviate.Client.Models.ExportCreateRequest! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.Models.ExportOperation!>!
 Weaviate.Client.ExportClient.CreateSync(Weaviate.Client.Models.ExportCreateRequest! request, System.TimeSpan? timeout = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.Models.Export!>!
 Weaviate.Client.ExportClient.GetStatus(Weaviate.Client.Models.BackupBackend! backend, string! id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.Models.Export!>!
@@ -3741,7 +3741,7 @@ Weaviate.Client.Models.ExportCreateRequest.Deconstruct(out string! Id, out Weavi
 Weaviate.Client.Models.ExportCreateRequest.ExcludeCollections.get -> Weaviate.Client.Internal.AutoArray<string!>?
 Weaviate.Client.Models.ExportCreateRequest.ExcludeCollections.init -> void
 Weaviate.Client.Models.ExportCreateRequest.ExportCreateRequest(Weaviate.Client.Models.ExportCreateRequest! original) -> void
-Weaviate.Client.Models.ExportCreateRequest.ExportCreateRequest(string! Id, Weaviate.Client.Models.BackupBackend! Backend, Weaviate.Client.Models.ExportFileFormat FileFormat = Weaviate.Client.Models.ExportFileFormat.Parquet, Weaviate.Client.Internal.AutoArray<string!>? IncludeCollections = null, Weaviate.Client.Internal.AutoArray<string!>? ExcludeCollections = null) -> void
+Weaviate.Client.Models.ExportCreateRequest.ExportCreateRequest(string! Id, Weaviate.Client.Models.BackupBackend! Backend, Weaviate.Client.Models.ExportFileFormat FileFormat, Weaviate.Client.Internal.AutoArray<string!>? IncludeCollections = null, Weaviate.Client.Internal.AutoArray<string!>? ExcludeCollections = null) -> void
 Weaviate.Client.Models.ExportCreateRequest.FileFormat.get -> Weaviate.Client.Models.ExportFileFormat
 Weaviate.Client.Models.ExportCreateRequest.FileFormat.init -> void
 Weaviate.Client.Models.ExportCreateRequest.Id.get -> string!
@@ -3752,11 +3752,11 @@ Weaviate.Client.Models.ExportFileFormat
 Weaviate.Client.Models.ExportFileFormat.Parquet = 0 -> Weaviate.Client.Models.ExportFileFormat
 Weaviate.Client.Models.ExportOperation
 Weaviate.Client.Models.ExportOperationBase
-Weaviate.Client.Models.ExportOperationBase.Cancel(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Weaviate.Client.Models.ExportOperationBase.Cancel(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
 Weaviate.Client.Models.ExportOperationBase.Current.get -> Weaviate.Client.Models.Export!
 Weaviate.Client.Models.ExportOperationBase.Dispose() -> void
 Weaviate.Client.Models.ExportOperationBase.DisposeAsync() -> System.Threading.Tasks.ValueTask
-Weaviate.Client.Models.ExportOperationBase.ExportOperationBase(Weaviate.Client.Models.Export! initial, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<Weaviate.Client.Models.Export!>!>! statusFetcher, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! operationCancel) -> void
+Weaviate.Client.Models.ExportOperationBase.ExportOperationBase(Weaviate.Client.Models.Export! initial, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<Weaviate.Client.Models.Export!>!>! statusFetcher, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>!>! operationCancel) -> void
 Weaviate.Client.Models.ExportOperationBase.IsCanceled.get -> bool
 Weaviate.Client.Models.ExportOperationBase.IsCompleted.get -> bool
 Weaviate.Client.Models.ExportOperationBase.IsSuccessful.get -> bool

--- a/src/Weaviate.Client/PublicAPI.Unshipped.txt
+++ b/src/Weaviate.Client/PublicAPI.Unshipped.txt
@@ -8,9 +8,6 @@ Weaviate.Client.Batch.TaskHandle.Status.get -> Weaviate.Client.Batch.BatchObject
 
 abstract Weaviate.Client.Models.Aggregate.Metric.<Clone>$() -> Weaviate.Client.Models.Aggregate.Metric!
 abstract Weaviate.Client.Models.Aggregate.Property.<Clone>$() -> Weaviate.Client.Models.Aggregate.Property!
-abstract Weaviate.Client.Models.BackupBackend.<Clone>$() -> Weaviate.Client.Models.BackupBackend!
-abstract Weaviate.Client.Models.BackupBackend.Path.get -> string?
-abstract Weaviate.Client.Models.BackupBackend.Provider.get -> Weaviate.Client.Models.BackupStorageProvider
 abstract Weaviate.Client.Models.BM25Operator.<Clone>$() -> Weaviate.Client.Models.BM25Operator!
 abstract Weaviate.Client.Models.CollectionConfigCommon.<Clone>$() -> Weaviate.Client.Models.CollectionConfigCommon!
 abstract Weaviate.Client.Models.GenerativeConfig.OpenAIBase.<Clone>$() -> Weaviate.Client.Models.GenerativeConfig.OpenAIBase!
@@ -2148,9 +2145,7 @@ virtual Weaviate.Client.Models.Backup.<Clone>$() -> Weaviate.Client.Models.Backu
 virtual Weaviate.Client.Models.Backup.EqualityContract.get -> System.Type!
 virtual Weaviate.Client.Models.Backup.Equals(Weaviate.Client.Models.Backup? other) -> bool
 virtual Weaviate.Client.Models.Backup.PrintMembers(System.Text.StringBuilder! builder) -> bool
-virtual Weaviate.Client.Models.BackupBackend.EqualityContract.get -> System.Type!
 virtual Weaviate.Client.Models.BackupBackend.Equals(Weaviate.Client.Models.BackupBackend? other) -> bool
-virtual Weaviate.Client.Models.BackupBackend.PrintMembers(System.Text.StringBuilder! builder) -> bool
 virtual Weaviate.Client.Models.BackupClientConfig.<Clone>$() -> Weaviate.Client.Models.BackupClientConfig!
 virtual Weaviate.Client.Models.BackupClientConfig.EqualityContract.get -> System.Type!
 virtual Weaviate.Client.Models.BackupClientConfig.Equals(Weaviate.Client.Models.BackupClientConfig? other) -> bool
@@ -2936,10 +2931,8 @@ Weaviate.Client.DefaultTokenServiceFactory.CreateAsync(Weaviate.Client.ClientCon
 Weaviate.Client.DefaultTokenServiceFactory.CreateSync(Weaviate.Client.ClientConfiguration! configuration) -> Weaviate.Client.ITokenService?
 Weaviate.Client.DefaultTokenServiceFactory.DefaultTokenServiceFactory() -> void
 Weaviate.Client.ExportClient
-Weaviate.Client.ExportClient.Cancel(Weaviate.Client.Models.BackupBackend! backend, string! id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
 Weaviate.Client.ExportClient.Create(Weaviate.Client.Models.ExportCreateRequest! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.Models.ExportOperation!>!
 Weaviate.Client.ExportClient.CreateSync(Weaviate.Client.Models.ExportCreateRequest! request, System.TimeSpan? timeout = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.Models.Export!>!
-Weaviate.Client.ExportClient.GetStatus(Weaviate.Client.Models.BackupBackend! backend, string! id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.Models.Export!>!
 Weaviate.Client.DependencyInjection.IWeaviateClientFactory
 Weaviate.Client.DependencyInjection.IWeaviateClientFactory.GetClient(string! name) -> Weaviate.Client.WeaviateClient!
 Weaviate.Client.DependencyInjection.IWeaviateClientFactory.GetClientAsync(string! name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.WeaviateClient!>!
@@ -3703,17 +3696,14 @@ Weaviate.Client.Models.DeletionStrategy.TimeBasedResolution = 2 -> Weaviate.Clie
 Weaviate.Client.Models.EmptyStringEnumConverter<T>
 Weaviate.Client.Models.EmptyStringEnumConverter<T>.EmptyStringEnumConverter() -> void
 Weaviate.Client.Models.Export
-Weaviate.Client.Models.Export.Backend.get -> Weaviate.Client.Models.BackupBackend!
 Weaviate.Client.Models.Export.Backend.init -> void
 Weaviate.Client.Models.Export.Collections.get -> string![]?
 Weaviate.Client.Models.Export.Collections.init -> void
 Weaviate.Client.Models.Export.CompletedAt.get -> System.DateTimeOffset?
 Weaviate.Client.Models.Export.CompletedAt.init -> void
-Weaviate.Client.Models.Export.Deconstruct(out string! Id, out Weaviate.Client.Models.BackupBackend! Backend, out string? Path, out string! StatusRaw, out string![]? Collections, out System.DateTimeOffset? StartedAt, out System.DateTimeOffset? CompletedAt, out string? Error) -> void
 Weaviate.Client.Models.Export.Error.get -> string?
 Weaviate.Client.Models.Export.Error.init -> void
 Weaviate.Client.Models.Export.Export(Weaviate.Client.Models.Export! original) -> void
-Weaviate.Client.Models.Export.Export(string! Id, Weaviate.Client.Models.BackupBackend! Backend, string? Path, string! StatusRaw, string![]? Collections, System.DateTimeOffset? StartedAt, System.DateTimeOffset? CompletedAt, string? Error) -> void
 Weaviate.Client.Models.Export.Path.get -> string?
 Weaviate.Client.Models.Export.Path.init -> void
 Weaviate.Client.Models.Export.Id.get -> string!
@@ -3735,13 +3725,10 @@ Weaviate.Client.Models.ExportClientConfig.PollInterval.init -> void
 Weaviate.Client.Models.ExportClientConfig.Timeout.get -> System.TimeSpan
 Weaviate.Client.Models.ExportClientConfig.Timeout.init -> void
 Weaviate.Client.Models.ExportCreateRequest
-Weaviate.Client.Models.ExportCreateRequest.Backend.get -> Weaviate.Client.Models.BackupBackend!
 Weaviate.Client.Models.ExportCreateRequest.Backend.init -> void
-Weaviate.Client.Models.ExportCreateRequest.Deconstruct(out string! Id, out Weaviate.Client.Models.BackupBackend! Backend, out Weaviate.Client.Models.ExportFileFormat FileFormat, out Weaviate.Client.Internal.AutoArray<string!>? IncludeCollections, out Weaviate.Client.Internal.AutoArray<string!>? ExcludeCollections) -> void
 Weaviate.Client.Models.ExportCreateRequest.ExcludeCollections.get -> Weaviate.Client.Internal.AutoArray<string!>?
 Weaviate.Client.Models.ExportCreateRequest.ExcludeCollections.init -> void
 Weaviate.Client.Models.ExportCreateRequest.ExportCreateRequest(Weaviate.Client.Models.ExportCreateRequest! original) -> void
-Weaviate.Client.Models.ExportCreateRequest.ExportCreateRequest(string! Id, Weaviate.Client.Models.BackupBackend! Backend, Weaviate.Client.Models.ExportFileFormat FileFormat, Weaviate.Client.Internal.AutoArray<string!>? IncludeCollections = null, Weaviate.Client.Internal.AutoArray<string!>? ExcludeCollections = null) -> void
 Weaviate.Client.Models.ExportCreateRequest.FileFormat.get -> Weaviate.Client.Models.ExportFileFormat
 Weaviate.Client.Models.ExportCreateRequest.FileFormat.init -> void
 Weaviate.Client.Models.ExportCreateRequest.Id.get -> string!
@@ -6952,3 +6939,46 @@ Weaviate.Client.DependencyInjection.WeaviateOptions.AddIntegration(string! integ
 Weaviate.Client.ClientConfigurationExtensions
 static Weaviate.Client.ClientConfigurationExtensions.WithIntegration(this Weaviate.Client.ClientConfiguration! config, string! integrationValue) -> Weaviate.Client.ClientConfiguration!
 static Weaviate.Client.WeaviateClientBuilderExtensions.WithIntegration(this Weaviate.Client.WeaviateClientBuilder! builder, string! integrationValue) -> Weaviate.Client.WeaviateClientBuilder!
+Weaviate.Client.ExportClient.Cancel(Weaviate.Client.Models.StorageBackend! backend, string! id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
+Weaviate.Client.ExportClient.GetStatus(Weaviate.Client.Models.StorageBackend! backend, string! id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.Models.Export!>!
+Weaviate.Client.Models.Export.Backend.get -> Weaviate.Client.Models.StorageBackend!
+Weaviate.Client.Models.Export.Deconstruct(out string! Id, out Weaviate.Client.Models.StorageBackend! Backend, out string? Path, out string! StatusRaw, out string![]? Collections, out System.DateTimeOffset? StartedAt, out System.DateTimeOffset? CompletedAt, out string? Error) -> void
+Weaviate.Client.Models.Export.Export(string! Id, Weaviate.Client.Models.StorageBackend! Backend, string? Path, string! StatusRaw, string![]? Collections, System.DateTimeOffset? StartedAt, System.DateTimeOffset? CompletedAt, string? Error) -> void
+Weaviate.Client.Models.ExportBackend
+Weaviate.Client.Models.ExportBackend.ExportBackend() -> void
+Weaviate.Client.Models.ExportBackend.ExportBackend(Weaviate.Client.Models.ExportBackend! original) -> void
+Weaviate.Client.Models.ExportCreateRequest.Backend.get -> Weaviate.Client.Models.StorageBackend!
+Weaviate.Client.Models.ExportCreateRequest.Deconstruct(out string! Id, out Weaviate.Client.Models.StorageBackend! Backend, out Weaviate.Client.Models.ExportFileFormat FileFormat, out Weaviate.Client.Internal.AutoArray<string!>? IncludeCollections, out Weaviate.Client.Internal.AutoArray<string!>? ExcludeCollections) -> void
+Weaviate.Client.Models.ExportCreateRequest.ExportCreateRequest(string! Id, Weaviate.Client.Models.StorageBackend! Backend, Weaviate.Client.Models.ExportFileFormat FileFormat, Weaviate.Client.Internal.AutoArray<string!>? IncludeCollections = null, Weaviate.Client.Internal.AutoArray<string!>? ExcludeCollections = null) -> void
+Weaviate.Client.Models.StorageBackend
+Weaviate.Client.Models.StorageBackend.StorageBackend() -> void
+Weaviate.Client.Models.StorageBackend.StorageBackend(Weaviate.Client.Models.StorageBackend! original) -> void
+abstract Weaviate.Client.Models.StorageBackend.<Clone>$() -> Weaviate.Client.Models.StorageBackend!
+abstract Weaviate.Client.Models.StorageBackend.Path.get -> string?
+abstract Weaviate.Client.Models.StorageBackend.Provider.get -> Weaviate.Client.Models.BackupStorageProvider
+override Weaviate.Client.Models.BackupBackend.EqualityContract.get -> System.Type!
+override Weaviate.Client.Models.BackupBackend.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override Weaviate.Client.Models.ExportBackend.EqualityContract.get -> System.Type!
+override Weaviate.Client.Models.ExportBackend.Equals(object? obj) -> bool
+override Weaviate.Client.Models.ExportBackend.GetHashCode() -> int
+override Weaviate.Client.Models.ExportBackend.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override Weaviate.Client.Models.ExportBackend.ToString() -> string!
+override Weaviate.Client.Models.StorageBackend.Equals(object? obj) -> bool
+override Weaviate.Client.Models.StorageBackend.GetHashCode() -> int
+override Weaviate.Client.Models.StorageBackend.ToString() -> string!
+override abstract Weaviate.Client.Models.BackupBackend.<Clone>$() -> Weaviate.Client.Models.BackupBackend!
+override abstract Weaviate.Client.Models.ExportBackend.<Clone>$() -> Weaviate.Client.Models.ExportBackend!
+override sealed Weaviate.Client.Models.BackupBackend.Equals(Weaviate.Client.Models.StorageBackend? other) -> bool
+override sealed Weaviate.Client.Models.ExportBackend.Equals(Weaviate.Client.Models.StorageBackend? other) -> bool
+static Weaviate.Client.Models.ExportBackend.Azure(string? bucket = null, string? path = null) -> Weaviate.Client.Models.StorageBackend!
+static Weaviate.Client.Models.ExportBackend.Filesystem(string? path = null) -> Weaviate.Client.Models.StorageBackend!
+static Weaviate.Client.Models.ExportBackend.GCS(string? bucket = null, string? path = null) -> Weaviate.Client.Models.StorageBackend!
+static Weaviate.Client.Models.ExportBackend.S3(string? bucket = null, string? path = null) -> Weaviate.Client.Models.StorageBackend!
+static Weaviate.Client.Models.ExportBackend.operator !=(Weaviate.Client.Models.ExportBackend? left, Weaviate.Client.Models.ExportBackend? right) -> bool
+static Weaviate.Client.Models.ExportBackend.operator ==(Weaviate.Client.Models.ExportBackend? left, Weaviate.Client.Models.ExportBackend? right) -> bool
+static Weaviate.Client.Models.StorageBackend.operator !=(Weaviate.Client.Models.StorageBackend? left, Weaviate.Client.Models.StorageBackend? right) -> bool
+static Weaviate.Client.Models.StorageBackend.operator ==(Weaviate.Client.Models.StorageBackend? left, Weaviate.Client.Models.StorageBackend? right) -> bool
+virtual Weaviate.Client.Models.ExportBackend.Equals(Weaviate.Client.Models.ExportBackend? other) -> bool
+virtual Weaviate.Client.Models.StorageBackend.EqualityContract.get -> System.Type!
+virtual Weaviate.Client.Models.StorageBackend.Equals(Weaviate.Client.Models.StorageBackend? other) -> bool
+virtual Weaviate.Client.Models.StorageBackend.PrintMembers(System.Text.StringBuilder! builder) -> bool

--- a/src/Weaviate.Client/Rest/Endpoints.cs
+++ b/src/Weaviate.Client/Rest/Endpoints.cs
@@ -313,6 +313,11 @@ internal static partial class WeaviateEndpoints
         return ep;
     }
 
+    // Export endpoints
+    internal static string Exports(string backend) => $"export/{backend}";
+
+    internal static string ExportStatus(string backend, string id) => $"export/{backend}/{id}";
+
     // Users endpoints
     /// <summary>
     /// Userses the own info

--- a/src/Weaviate.Client/Rest/Export.cs
+++ b/src/Weaviate.Client/Rest/Export.cs
@@ -36,7 +36,7 @@ internal partial class WeaviateRestClient
         return await response.DecodeAsync<Dto.ExportStatusResponse>(cancellationToken);
     }
 
-    internal async Task ExportCancel(
+    internal async Task<bool> ExportCancel(
         BackupStorageProvider backend,
         string id,
         CancellationToken cancellationToken = default
@@ -46,10 +46,15 @@ internal partial class WeaviateRestClient
             WeaviateEndpoints.ExportStatus(backend.ToEnumMemberString()!, id),
             cancellationToken
         );
+        if (response.StatusCode == HttpStatusCode.Conflict)
+        {
+            return false;
+        }
         await response.ManageStatusCode(
             [HttpStatusCode.OK, HttpStatusCode.NoContent],
             "export cancel",
             ResourceType.Export
         );
+        return true;
     }
 }

--- a/src/Weaviate.Client/Rest/Export.cs
+++ b/src/Weaviate.Client/Rest/Export.cs
@@ -1,0 +1,55 @@
+using System.Net;
+using System.Net.Http.Json;
+using Weaviate.Client.Models;
+
+namespace Weaviate.Client.Rest;
+
+internal partial class WeaviateRestClient
+{
+    internal async Task<Dto.ExportCreateResponse> ExportCreate(
+        BackupStorageProvider backend,
+        Dto.ExportCreateRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var response = await _httpClient.PostAsJsonAsync(
+            WeaviateEndpoints.Exports(backend.ToEnumMemberString()!),
+            request,
+            options: RestJsonSerializerOptions,
+            cancellationToken: cancellationToken
+        );
+        await response.ManageStatusCode([HttpStatusCode.OK], "create export", ResourceType.Export);
+        return await response.DecodeAsync<Dto.ExportCreateResponse>(cancellationToken);
+    }
+
+    internal async Task<Dto.ExportStatusResponse> ExportGetStatus(
+        BackupStorageProvider backend,
+        string id,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var response = await _httpClient.GetAsync(
+            WeaviateEndpoints.ExportStatus(backend.ToEnumMemberString()!, id),
+            cancellationToken
+        );
+        await response.ManageStatusCode([HttpStatusCode.OK], "export status", ResourceType.Export);
+        return await response.DecodeAsync<Dto.ExportStatusResponse>(cancellationToken);
+    }
+
+    internal async Task ExportCancel(
+        BackupStorageProvider backend,
+        string id,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var response = await _httpClient.DeleteAsync(
+            WeaviateEndpoints.ExportStatus(backend.ToEnumMemberString()!, id),
+            cancellationToken
+        );
+        await response.ManageStatusCode(
+            [HttpStatusCode.OK, HttpStatusCode.NoContent],
+            "export cancel",
+            ResourceType.Export
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ExportClient` to the C# client, matching the Python PR [weaviate/weaviate-python-client#1981](https://github.com/weaviate/weaviate-python-client/pull/1981)
- Follows the existing `BackupClient` pattern with operation-based polling
- Requires Weaviate server 1.37.0+ with `EXPORT_ENABLED=true`

## What's included

**Domain models** (`Models/Export.cs`)
- `ExportFileFormat` enum (Parquet)
- `ExportStatus` enum (Started, Transferring, Success, Failed, Canceled)
- `ShardExportStatus` enum (Transferring, Success, Failed, Skipped)
- `Export` record — returned by create/status; includes `Path`, `ShardStatus`, `TookInMs`
- `ShardExportProgress` record — per-shard progress with `SkipReason`
- `ExportCreateRequest` record — `Id`, `Backend`, `FileFormat`, `IncludeCollections`, `ExcludeCollections`

**Client** (`ExportClient.cs`)
- `client.Export.Create(request)` — starts export, returns `ExportOperation` for polling
- `client.Export.CreateSync(request)` — starts export and waits for completion
- `client.Export.GetStatus(backend, id)` — checks status of an export
- `client.Export.Cancel(backend, id)` — cancels a running export
- `ExportClient.Config` — static `ExportClientConfig` (poll interval, timeout)

**REST layer** (`Rest/Export.cs`, `Rest/Endpoints.cs`)
- `POST /export/{backend}` — create
- `GET /export/{backend}/{id}` — status
- `DELETE /export/{backend}/{id}` — cancel (accepts 204 and 409)

**Operation polling** (`Models/ExportOperationBase.cs`, `Models/ExportOperation.cs`)
- Background refresh with `WaitForCompletion(timeout?)` and `Cancel()`
- `IDisposable` / `IAsyncDisposable` for resource cleanup

**Spec** — synced `openapi.json` from `weaviate/weaviate v1.37.0` (stable release removed `Config` DTO from export request that appeared in a pre-release spec)

## Test plan

- [x] 12 unit tests covering request serialization, status mapping, shard progress, cancellation
- [ ] Integration tests require server with `EXPORT_ENABLED=true` (see `src/Weaviate.Client.Tests/Integration/TestExports.cs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)