### PR TITLE
feat: tokenize endpoints + property-level TextAnalyzer + StopwordPresets (Weaviate 1.37.0+)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["1.32.27", "1.33.18", "1.34.20", "1.35.16", "1.36.10", "1.37.1"]
+        version: ["1.32.27", "1.33.18", "1.34.20", "1.35.16", "1.36.10", "1.37.2"]
     uses: ./.github/workflows/test-on-weaviate-version.yml
     secrets: inherit
     with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
 
+#### Tokenization
+
+- **Tokenize Endpoints** ([#329](https://github.com/weaviate/csharp-client/pull/329)): Expose the `POST /v1/tokenize` and `POST /v1/schema/{class}/properties/{prop}/tokenize` endpoints introduced in Weaviate 1.37.0. Inspect how text is tokenized for a given method and analyzer configuration, or how a specific collection property would tokenize it. Access via `client.Tokenize.Text(...)` and `collection.Tokenize.Property(...)`. `AsciiFoldConfig` is modeled as a nullable record so the invalid "ignore without fold" state is unrepresentable. See [TOKENIZE_API_USAGE.md](docs/TOKENIZE_API_USAGE.md). Requires Weaviate ≥ 1.37.0.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Tokenization
 
 - **Tokenize Endpoints** ([#329](https://github.com/weaviate/csharp-client/pull/329)): Expose the `POST /v1/tokenize` and `POST /v1/schema/{class}/properties/{prop}/tokenize` endpoints introduced in Weaviate 1.37.0. Inspect how text is tokenized for a given method and analyzer configuration, or how a specific collection property would tokenize it. Access via `client.Tokenize.Text(...)` and `collection.Tokenize.Property(...)`. `AsciiFoldConfig` is modeled as a nullable record so the invalid "ignore without fold" state is unrepresentable. See [TOKENIZE_API_USAGE.md](docs/TOKENIZE_API_USAGE.md). Requires Weaviate ≥ 1.37.0.
+- **Property-Level `TextAnalyzerConfig`** ([#329](https://github.com/weaviate/csharp-client/pull/329)): `Property.TextAnalyzer` (also applies to nested properties) lets a collection schema pin ASCII folding and/or a stopword preset per property at index time. The same `TextAnalyzerConfig` record is reused from the `Tokenize` endpoint so tokenize-at-query and index-at-insert stay aligned. A preflight version check on `CollectionsClient.Create` raises `WeaviateVersionMismatchException` when the server is older than 1.37.0. Requires Weaviate ≥ 1.37.0.
+- **Collection-Level `StopwordPresets`** ([#329](https://github.com/weaviate/csharp-client/pull/329)): `InvertedIndexConfig.StopwordPresets` and `InvertedIndexConfigUpdate.StopwordPresets` define named preset name → word-list maps on the inverted-index config. Properties reference these presets via `TextAnalyzer.StopwordPreset`. Preset changes flow through `CollectionClient.Config.Update(c => c.InvertedIndexConfig.StopwordPresets = ...)`. Requires Weaviate ≥ 1.37.0.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ For more detailed information on specific features, please refer to the official
 - **[Backup API Usage](docs/BACKUP_API_USAGE.md)**: Creating and restoring backups
 - **[Nodes API Usage](docs/NODES_API_USAGE.md)**: Querying cluster node information
 - **[Aggregate Result Accessors](docs/AGGREGATE_RESULT_ACCESSORS.md)**: Type-safe access to aggregation results
+- **[Tokenize API Usage](docs/TOKENIZE_API_USAGE.md)**: Inspect how text is tokenized with a given method or for a specific collection property. Requires Weaviate ≥ 1.37.0.
 - **[Microsoft.Extensions.VectorData Integration](docs/VECTORDATA.md)**: Standard .NET vector store abstraction support
 
 ---

--- a/docs/TOKENIZE_API_USAGE.md
+++ b/docs/TOKENIZE_API_USAGE.md
@@ -46,9 +46,9 @@ The `PropertyTokenization` enum covers all nine server-supported strategies:
 | `Field` | `"  Hello World  "` | `["Hello World"]` *(entire field, trimmed)* |
 | `Trigram` | `"Hello"` | `["hel", "ell", "llo"]` |
 | `Gse` | Chinese/Japanese | Requires `ENABLE_TOKENIZER_GSE=true` on the server |
-| `GseCh` | Chinese-only GSE | Requires `ENABLE_TOKENIZER_GSE_CH=true` |
-| `KagomeJa` | Japanese | Requires `ENABLE_TOKENIZER_KAGOME_JA=true` |
-| `KagomeKr` | Korean | Requires `ENABLE_TOKENIZER_KAGOME_KR=true` |
+| `Gse_ch` | Chinese-only GSE | Requires `ENABLE_TOKENIZER_GSE_CH=true` |
+| `Kagome_ja` | Japanese | Requires `ENABLE_TOKENIZER_KAGOME_JA=true` |
+| `Kagome_kr` | Korean | Requires `ENABLE_TOKENIZER_KAGOME_KR=true` |
 
 ## Ad-hoc Tokenization (`client.Tokenize.Text`)
 
@@ -73,24 +73,26 @@ Task<TokenizeResult> Tokenize.Text(
     string text,
     PropertyTokenization tokenization,
     TextAnalyzerConfig? analyzerConfig = null,
-    IDictionary<string, StopwordConfig>? stopwordPresets = null,
+    StopwordConfig? stopwords = null,
+    IDictionary<string, IList<string>>? stopwordPresets = null,
     CancellationToken cancellationToken = default
 );
 ```
+
+`stopwords` and `stopwordPresets` are mutually exclusive — passing both throws `ArgumentException`.
 
 ## Property-scoped Tokenization (`collection.Tokenize.Property`)
 
 When you want to see how a specific property would tokenize text — using that property's configured tokenization — use the collection-scoped variant:
 
 ```csharp
-var collection = await client.Collections.Get("Article");
+var collection = client.Collections.Use("Article");
 
 var result = await collection.Tokenize.Property(
     propertyName: "title",
     text: "  Hello World  "
 );
 
-Console.WriteLine(result.Tokenization);          // Field (whatever the property is configured with)
 Console.WriteLine(string.Join(", ", result.Indexed)); // Hello World
 ```
 
@@ -155,20 +157,21 @@ var result = await client.Tokenize.Text(
 
 ## Stopwords
 
-For more control, define a named preset via the `stopwordPresets` dictionary and reference it from `StopwordPreset`.
+There are two ways to feed stopwords into a tokenize call:
 
-### Add words to a preset
+1. **`stopwordPresets`** — a `name → word-list` dictionary. Each value is a flat list of stopwords for that preset. `TextAnalyzerConfig.StopwordPreset` then references one by name. A preset name that matches a built-in (`"en"`, `"none"`) replaces the built-in for this call.
+2. **`stopwords`** — a one-off `StopwordConfig` (`preset` + `additions` + `removals`) applied directly. Mirrors the collection-level `invertedIndexConfig.stopwords` shape.
+
+The two parameters are **mutually exclusive** — pass one or the other.
+
+### Custom named preset
 
 ```csharp
 var cfg = new TextAnalyzerConfig { StopwordPreset = "custom" };
 
-var presets = new Dictionary<string, StopwordConfig>
+var presets = new Dictionary<string, IList<string>>
 {
-    ["custom"] = new StopwordConfig
-    {
-        Preset = StopwordConfig.Presets.None,
-        Additions = ["test"],
-    },
+    ["custom"] = new[] { "test" },
 };
 
 var result = await client.Tokenize.Text(
@@ -182,28 +185,24 @@ var result = await client.Tokenize.Text(
 // result.Query   → ["hello", "world"]          ("test" dropped)
 ```
 
-### Start from a base preset and remove words
+### One-off `stopwords` block
+
+Use `stopwords` when you want a base preset plus tweaks for a single call without defining a named preset:
 
 ```csharp
-var cfg = new TextAnalyzerConfig { StopwordPreset = "en-no-the" };
-
-var presets = new Dictionary<string, StopwordConfig>
-{
-    ["en-no-the"] = new StopwordConfig
-    {
-        Preset = StopwordConfig.Presets.EN,
-        Removals = ["the"],
-    },
-};
-
 var result = await client.Tokenize.Text(
     "the quick",
     PropertyTokenization.Word,
-    analyzerConfig: cfg,
-    stopwordPresets: presets
+    stopwords: new StopwordConfig
+    {
+        Preset = StopwordConfig.Presets.EN,
+        Removals = ["the"],
+    }
 );
 
-// "the" is no longer a stopword in this preset, so it survives in both lists.
+// "the" was removed from the EN base, so it survives in both lists:
+// result.Indexed → ["the", "quick"]
+// result.Query   → ["the", "quick"]
 ```
 
 ### Combining folding and stopwords
@@ -227,17 +226,14 @@ var result = await client.Tokenize.Text(
 
 ## Result Shape
 
-`TokenizeResult` is a sealed record:
+`TokenizeResult` is a sealed record with two members:
 
 | Member | Type | Description |
 |---|---|---|
-| `Tokenization` | `PropertyTokenization` | The method that was applied. |
 | `Indexed` | `ImmutableList<string>` | Tokens as stored in the inverted index. |
 | `Query` | `ImmutableList<string>` | Tokens used at query time (after stopword removal). |
-| `AnalyzerConfig` | `TextAnalyzerConfig?` | Echo of the analyzer config that was applied, or `null`. |
-| `StopwordConfig` | `StopwordConfig?` | Echo of the resolved stopword config, or `null`. |
 
-The `AnalyzerConfig` echo is the server's view of what was applied — useful for verifying that your config was parsed correctly. The round-trip also normalizes wire-format quirks (the server represents `asciiFold` as a `bool` + separate `asciiFoldIgnore[]`, but the client unwraps it back into the nested `AsciiFoldConfig` record).
+The two lists differ when stopwords are configured: stopwords stay in `Indexed` (so BM25 can count document length) but are dropped from `Query` so they don't inflate match scores.
 
 ## Property-level Text Analyzer (schema)
 
@@ -252,8 +248,8 @@ await client.Collections.Create(new CollectionCreateParams
         new Property
         {
             Name = "title",
-            DataType = [DataType.Text],
-            Tokenization = PropertyTokenization.Word,
+            DataType = DataType.Text,
+            PropertyTokenization = PropertyTokenization.Word,
             TextAnalyzer = new TextAnalyzerConfig
             {
                 AsciiFold = new AsciiFoldConfig(),
@@ -289,7 +285,8 @@ await client.Collections.Create(new CollectionCreateParams
         new Property
         {
             Name = "body",
-            DataType = [DataType.Text],
+            DataType = DataType.Text,
+            PropertyTokenization = PropertyTokenization.Word,
             TextAnalyzer = new TextAnalyzerConfig { StopwordPreset = "fr" },
         },
     ],
@@ -336,7 +333,7 @@ var docTokens   = (await collection.Tokenize.Property("body", "I was running")).
 
 ### Verifying analyzer config round-trip
 
-When you configure ASCII folding or a stopword preset, the server echoes back its interpretation on every call:
+Pass the analyzer config to `Tokenize.Text` and check the tokens it returns:
 
 ```csharp
 var cfg = new TextAnalyzerConfig
@@ -347,6 +344,6 @@ var cfg = new TextAnalyzerConfig
 
 var result = await client.Tokenize.Text("L'école", PropertyTokenization.Word, analyzerConfig: cfg);
 
-Debug.Assert(result.AnalyzerConfig!.AsciiFold!.Ignore!.SequenceEqual(new[] { "é" }));
-Debug.Assert(result.AnalyzerConfig.StopwordPreset == "en");
+// AsciiFold is on, but "é" is in Ignore → "école" survives intact.
+Debug.Assert(result.Indexed.Contains("école"));
 ```

--- a/docs/TOKENIZE_API_USAGE.md
+++ b/docs/TOKENIZE_API_USAGE.md
@@ -1,0 +1,277 @@
+# Tokenize API Usage Guide
+
+> **Version Requirement:**
+> The tokenize endpoints require Weaviate **v1.37.0** or newer. Calls against earlier versions throw `WeaviateVersionMismatchException`.
+
+This guide covers the Weaviate C# client's tokenize API — a pair of endpoints that let you inspect how the server would tokenize a piece of text, either with an ad-hoc tokenization strategy or using the one already configured on a collection property.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Tokenization Methods](#tokenization-methods)
+- [Ad-hoc Tokenization (`client.Tokenize.Text`)](#ad-hoc-tokenization-clienttokenizetext)
+- [Property-scoped Tokenization (`collection.Tokenize.Property`)](#property-scoped-tokenization-collectiontokenizeproperty)
+- [Analyzer Configuration](#analyzer-configuration)
+- [Stopwords](#stopwords)
+- [Result Shape](#result-shape)
+- [Common Patterns](#common-patterns)
+
+## Overview
+
+The tokenize API exposes two REST endpoints:
+
+| Method | Endpoint | Use when… |
+|---|---|---|
+| `client.Tokenize.Text(...)` | `POST /v1/tokenize` | You want to preview tokenization for arbitrary text with any method/config — no collection required. |
+| `collection.Tokenize.Property(...)` | `POST /v1/schema/{class}/properties/{prop}/tokenize` | You want to tokenize text *exactly as it would be indexed* by a specific property of an existing collection. |
+
+Both return a `TokenizeResult` containing two token lists:
+
+- **`Indexed`** — tokens as they are stored in the inverted index.
+- **`Query`** — tokens as they are used for query matching (after stopword removal, etc.).
+
+These differ when stopwords are configured: a stopword like `"the"` is still indexed (so `BM25` can count it), but dropped from `Query` so it doesn't inflate match scores.
+
+## Tokenization Methods
+
+The `PropertyTokenization` enum covers all nine server-supported strategies:
+
+| Method | Input | Output (`Indexed`) |
+|---|---|---|
+| `Word` | `"The quick brown fox"` | `["the", "quick", "brown", "fox"]` |
+| `Lowercase` | `"Hello World Test"` | `["hello", "world", "test"]` |
+| `Whitespace` | `"Hello World Test"` | `["Hello", "World", "Test"]` |
+| `Field` | `"  Hello World  "` | `["Hello World"]` *(entire field, trimmed)* |
+| `Trigram` | `"Hello"` | `["hel", "ell", "llo"]` |
+| `Gse` | Chinese/Japanese | Requires `ENABLE_TOKENIZER_GSE=true` on the server |
+| `GseCh` | Chinese-only GSE | Requires `ENABLE_TOKENIZER_GSE_CH=true` |
+| `KagomeJa` | Japanese | Requires `ENABLE_TOKENIZER_KAGOME_JA=true` |
+| `KagomeKr` | Korean | Requires `ENABLE_TOKENIZER_KAGOME_KR=true` |
+
+## Ad-hoc Tokenization (`client.Tokenize.Text`)
+
+The simplest call takes only a text and a tokenization method:
+
+```csharp
+using Weaviate.Client.Models;
+
+var result = await client.Tokenize.Text(
+    text: "The quick brown fox",
+    tokenization: PropertyTokenization.Word
+);
+
+Console.WriteLine(string.Join(", ", result.Indexed));
+// the, quick, brown, fox
+```
+
+Signature:
+
+```csharp
+Task<TokenizeResult> Tokenize.Text(
+    string text,
+    PropertyTokenization tokenization,
+    TokenizeAnalyzerConfig? analyzerConfig = null,
+    IDictionary<string, StopwordConfig>? stopwordPresets = null,
+    CancellationToken cancellationToken = default
+);
+```
+
+## Property-scoped Tokenization (`collection.Tokenize.Property`)
+
+When you want to see how a specific property would tokenize text — using that property's configured tokenization — use the collection-scoped variant:
+
+```csharp
+var collection = await client.Collections.Get("Article");
+
+var result = await collection.Tokenize.Property(
+    propertyName: "title",
+    text: "  Hello World  "
+);
+
+Console.WriteLine(result.Tokenization);          // Field (whatever the property is configured with)
+Console.WriteLine(string.Join(", ", result.Indexed)); // Hello World
+```
+
+The server uses the property's configured tokenization method and any analyzer config attached to the property — you don't pass either yourself.
+
+## Analyzer Configuration
+
+`TokenizeAnalyzerConfig` controls two optional analyzer stages: **ASCII folding** and **stopword removal**.
+
+### ASCII Folding
+
+`AsciiFoldConfig` is a nullable record — `null` means folding is disabled, non-`null` means it's enabled. The `Ignore` list lets you exempt specific characters from folding.
+
+```csharp
+var cfg = new TokenizeAnalyzerConfig
+{
+    AsciiFold = new AsciiFoldConfig(), // folding enabled, nothing ignored
+};
+
+var result = await client.Tokenize.Text(
+    "L'école est fermée",
+    PropertyTokenization.Word,
+    analyzerConfig: cfg
+);
+// result.Indexed == ["l", "ecole", "est", "fermee"]
+```
+
+Ignore a specific character:
+
+```csharp
+var cfg = new TokenizeAnalyzerConfig
+{
+    AsciiFold = new AsciiFoldConfig(Ignore: ["é"]),
+};
+
+var result = await client.Tokenize.Text(
+    "L'école est fermée",
+    PropertyTokenization.Word,
+    analyzerConfig: cfg
+);
+// result.Indexed == ["l", "école", "est", "fermée"]
+```
+
+> **Tip:** Modeling `AsciiFold` as a nullable record makes the "ignore without fold" state unrepresentable — you can't accidentally pass `Ignore` without enabling folding.
+
+### Stopwords
+
+Use a built-in preset (`"en"`, `"none"`) via the `StopwordPreset` field:
+
+```csharp
+var cfg = new TokenizeAnalyzerConfig { StopwordPreset = "en" };
+
+var result = await client.Tokenize.Text(
+    "The quick brown fox",
+    PropertyTokenization.Word,
+    analyzerConfig: cfg
+);
+
+// result.Indexed  → ["the", "quick", "brown", "fox"]     (all tokens kept in index)
+// result.Query    → ["quick", "brown", "fox"]            ("the" removed for queries)
+```
+
+## Stopwords
+
+For more control, define a named preset via the `stopwordPresets` dictionary and reference it from `StopwordPreset`.
+
+### Add words to a preset
+
+```csharp
+var cfg = new TokenizeAnalyzerConfig { StopwordPreset = "custom" };
+
+var presets = new Dictionary<string, StopwordConfig>
+{
+    ["custom"] = new StopwordConfig
+    {
+        Preset = StopwordConfig.Presets.None,
+        Additions = ["test"],
+    },
+};
+
+var result = await client.Tokenize.Text(
+    "hello world test",
+    PropertyTokenization.Word,
+    analyzerConfig: cfg,
+    stopwordPresets: presets
+);
+
+// result.Indexed → ["hello", "world", "test"]
+// result.Query   → ["hello", "world"]          ("test" dropped)
+```
+
+### Start from a base preset and remove words
+
+```csharp
+var cfg = new TokenizeAnalyzerConfig { StopwordPreset = "en-no-the" };
+
+var presets = new Dictionary<string, StopwordConfig>
+{
+    ["en-no-the"] = new StopwordConfig
+    {
+        Preset = StopwordConfig.Presets.EN,
+        Removals = ["the"],
+    },
+};
+
+var result = await client.Tokenize.Text(
+    "the quick",
+    PropertyTokenization.Word,
+    analyzerConfig: cfg,
+    stopwordPresets: presets
+);
+
+// "the" is no longer a stopword in this preset, so it survives in both lists.
+```
+
+### Combining folding and stopwords
+
+```csharp
+var cfg = new TokenizeAnalyzerConfig
+{
+    AsciiFold = new AsciiFoldConfig(Ignore: ["é"]),
+    StopwordPreset = "en",
+};
+
+var result = await client.Tokenize.Text(
+    "The école est fermée",
+    PropertyTokenization.Word,
+    analyzerConfig: cfg
+);
+
+// result.Indexed → ["the", "école", "est", "fermee"]
+// result.Query   → ["école", "est", "fermee"]         ("the" dropped)
+```
+
+## Result Shape
+
+`TokenizeResult` is a sealed record:
+
+| Member | Type | Description |
+|---|---|---|
+| `Tokenization` | `PropertyTokenization` | The method that was applied. |
+| `Indexed` | `ImmutableList<string>` | Tokens as stored in the inverted index. |
+| `Query` | `ImmutableList<string>` | Tokens used at query time (after stopword removal). |
+| `AnalyzerConfig` | `TokenizeAnalyzerConfig?` | Echo of the analyzer config that was applied, or `null`. |
+| `StopwordConfig` | `StopwordConfig?` | Echo of the resolved stopword config, or `null`. |
+
+The `AnalyzerConfig` echo is the server's view of what was applied — useful for verifying that your config was parsed correctly. The round-trip also normalizes wire-format quirks (the server represents `asciiFold` as a `bool` + separate `asciiFoldIgnore[]`, but the client unwraps it back into the nested `AsciiFoldConfig` record).
+
+## Common Patterns
+
+### Previewing a query
+
+Use `collection.Tokenize.Property` to see exactly what tokens the server will match your search against:
+
+```csharp
+var tokens = (await collection.Tokenize.Property("title", userQuery)).Query;
+// Show tokens in the UI as "searching for: X, Y, Z"
+```
+
+### Debugging a BM25 miss
+
+If a search misses a term you expected, tokenize both the query and a sample document with the same property:
+
+```csharp
+var queryTokens = (await collection.Tokenize.Property("body", "running")).Query;
+var docTokens   = (await collection.Tokenize.Property("body", "I was running")).Indexed;
+
+// If the sets don't intersect, BM25 can't match — check for stemming / stopwords.
+```
+
+### Verifying analyzer config round-trip
+
+When you configure ASCII folding or a stopword preset, the server echoes back its interpretation on every call:
+
+```csharp
+var cfg = new TokenizeAnalyzerConfig
+{
+    AsciiFold = new AsciiFoldConfig(Ignore: ["é"]),
+    StopwordPreset = "en",
+};
+
+var result = await client.Tokenize.Text("L'école", PropertyTokenization.Word, analyzerConfig: cfg);
+
+Debug.Assert(result.AnalyzerConfig!.AsciiFold!.Ignore!.SequenceEqual(new[] { "é" }));
+Debug.Assert(result.AnalyzerConfig.StopwordPreset == "en");
+```

--- a/docs/TOKENIZE_API_USAGE.md
+++ b/docs/TOKENIZE_API_USAGE.md
@@ -14,6 +14,8 @@ This guide covers the Weaviate C# client's tokenize API — a pair of endpoints 
 - [Analyzer Configuration](#analyzer-configuration)
 - [Stopwords](#stopwords)
 - [Result Shape](#result-shape)
+- [Property-level Text Analyzer (schema)](#property-level-text-analyzer-schema)
+- [Collection-level Stopword Presets (schema)](#collection-level-stopword-presets-schema)
 - [Common Patterns](#common-patterns)
 
 ## Overview
@@ -70,7 +72,7 @@ Signature:
 Task<TokenizeResult> Tokenize.Text(
     string text,
     PropertyTokenization tokenization,
-    TokenizeAnalyzerConfig? analyzerConfig = null,
+    TextAnalyzerConfig? analyzerConfig = null,
     IDictionary<string, StopwordConfig>? stopwordPresets = null,
     CancellationToken cancellationToken = default
 );
@@ -96,14 +98,14 @@ The server uses the property's configured tokenization method and any analyzer c
 
 ## Analyzer Configuration
 
-`TokenizeAnalyzerConfig` controls two optional analyzer stages: **ASCII folding** and **stopword removal**.
+`TextAnalyzerConfig` controls two optional analyzer stages: **ASCII folding** and **stopword removal**.
 
 ### ASCII Folding
 
 `AsciiFoldConfig` is a nullable record — `null` means folding is disabled, non-`null` means it's enabled. The `Ignore` list lets you exempt specific characters from folding.
 
 ```csharp
-var cfg = new TokenizeAnalyzerConfig
+var cfg = new TextAnalyzerConfig
 {
     AsciiFold = new AsciiFoldConfig(), // folding enabled, nothing ignored
 };
@@ -119,7 +121,7 @@ var result = await client.Tokenize.Text(
 Ignore a specific character:
 
 ```csharp
-var cfg = new TokenizeAnalyzerConfig
+var cfg = new TextAnalyzerConfig
 {
     AsciiFold = new AsciiFoldConfig(Ignore: ["é"]),
 };
@@ -139,7 +141,7 @@ var result = await client.Tokenize.Text(
 Use a built-in preset (`"en"`, `"none"`) via the `StopwordPreset` field:
 
 ```csharp
-var cfg = new TokenizeAnalyzerConfig { StopwordPreset = "en" };
+var cfg = new TextAnalyzerConfig { StopwordPreset = "en" };
 
 var result = await client.Tokenize.Text(
     "The quick brown fox",
@@ -158,7 +160,7 @@ For more control, define a named preset via the `stopwordPresets` dictionary and
 ### Add words to a preset
 
 ```csharp
-var cfg = new TokenizeAnalyzerConfig { StopwordPreset = "custom" };
+var cfg = new TextAnalyzerConfig { StopwordPreset = "custom" };
 
 var presets = new Dictionary<string, StopwordConfig>
 {
@@ -183,7 +185,7 @@ var result = await client.Tokenize.Text(
 ### Start from a base preset and remove words
 
 ```csharp
-var cfg = new TokenizeAnalyzerConfig { StopwordPreset = "en-no-the" };
+var cfg = new TextAnalyzerConfig { StopwordPreset = "en-no-the" };
 
 var presets = new Dictionary<string, StopwordConfig>
 {
@@ -207,7 +209,7 @@ var result = await client.Tokenize.Text(
 ### Combining folding and stopwords
 
 ```csharp
-var cfg = new TokenizeAnalyzerConfig
+var cfg = new TextAnalyzerConfig
 {
     AsciiFold = new AsciiFoldConfig(Ignore: ["é"]),
     StopwordPreset = "en",
@@ -232,10 +234,83 @@ var result = await client.Tokenize.Text(
 | `Tokenization` | `PropertyTokenization` | The method that was applied. |
 | `Indexed` | `ImmutableList<string>` | Tokens as stored in the inverted index. |
 | `Query` | `ImmutableList<string>` | Tokens used at query time (after stopword removal). |
-| `AnalyzerConfig` | `TokenizeAnalyzerConfig?` | Echo of the analyzer config that was applied, or `null`. |
+| `AnalyzerConfig` | `TextAnalyzerConfig?` | Echo of the analyzer config that was applied, or `null`. |
 | `StopwordConfig` | `StopwordConfig?` | Echo of the resolved stopword config, or `null`. |
 
 The `AnalyzerConfig` echo is the server's view of what was applied — useful for verifying that your config was parsed correctly. The round-trip also normalizes wire-format quirks (the server represents `asciiFold` as a `bool` + separate `asciiFoldIgnore[]`, but the client unwraps it back into the nested `AsciiFoldConfig` record).
+
+## Property-level Text Analyzer (schema)
+
+Beyond the ad-hoc tokenize endpoint, Weaviate 1.37.0 also lets you pin analyzer options directly on a property at **collection-creation time**. The same `TextAnalyzerConfig` record is reused: whatever you would pass to `client.Tokenize.Text(...)` can also be attached to a property so every value indexed through that property gets the same treatment.
+
+```csharp
+await client.Collections.Create(new CollectionCreateParams
+{
+    Name = "Article",
+    Properties =
+    [
+        new Property
+        {
+            Name = "title",
+            DataType = [DataType.Text],
+            Tokenization = PropertyTokenization.Word,
+            TextAnalyzer = new TextAnalyzerConfig
+            {
+                AsciiFold = new AsciiFoldConfig(),
+                StopwordPreset = "en",
+            },
+        },
+    ],
+});
+```
+
+Nested properties (object / object-array) accept `TextAnalyzer` too — they are `Property` records themselves, so the same field is available on every depth.
+
+> **Version requirement:** `Property.TextAnalyzer` is only wired up for servers at Weaviate ≥ 1.37.0. `CollectionsClient.Create` performs a preflight version check and throws `WeaviateVersionMismatchException` if the connected server is older, before the schema request is sent.
+
+## Collection-level Stopword Presets (schema)
+
+Named stopword lists live on the collection's inverted-index config. A preset is a `preset-name → word-list` pair; properties reference one by name via `TextAnalyzer.StopwordPreset`.
+
+```csharp
+await client.Collections.Create(new CollectionCreateParams
+{
+    Name = "Article",
+    InvertedIndexConfig = new InvertedIndexConfig
+    {
+        StopwordPresets = new Dictionary<string, IList<string>>
+        {
+            ["fr"] = new[] { "le", "la", "les" },
+            ["custom_en"] = new[] { "foo", "bar" },
+        },
+    },
+    Properties =
+    [
+        new Property
+        {
+            Name = "body",
+            DataType = [DataType.Text],
+            TextAnalyzer = new TextAnalyzerConfig { StopwordPreset = "fr" },
+        },
+    ],
+});
+```
+
+Updating presets on an existing collection goes through the normal update path:
+
+```csharp
+await collection.Config.Update(c =>
+{
+    c.InvertedIndexConfig.StopwordPresets = new Dictionary<string, IList<string>>
+    {
+        ["fr"] = new[] { "le", "la", "les", "un", "une" },
+    };
+});
+```
+
+Setting `StopwordPresets` replaces the whole preset map on the server. The server rejects removing a preset that is still referenced by a property's `TextAnalyzer.StopwordPreset` — keep preset removals and property-config changes in the same update, or unwire the property first.
+
+> **Version requirement:** Requires Weaviate ≥ 1.37.0. The preflight in `CollectionsClient.Create` also trips on `InvertedIndexConfig.StopwordPresets` before contacting the server.
 
 ## Common Patterns
 
@@ -264,7 +339,7 @@ var docTokens   = (await collection.Tokenize.Property("body", "I was running")).
 When you configure ASCII folding or a stopword preset, the server echoes back its interpretation on every call:
 
 ```csharp
-var cfg = new TokenizeAnalyzerConfig
+var cfg = new TextAnalyzerConfig
 {
     AsciiFold = new AsciiFoldConfig(Ignore: ["é"]),
     StopwordPreset = "en",

--- a/src/Weaviate.Client.Tests/Integration/TestCollectionTextAnalyzer.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestCollectionTextAnalyzer.cs
@@ -1,0 +1,462 @@
+using Weaviate.Client.Models;
+
+namespace Weaviate.Client.Tests.Integration;
+
+/// <summary>
+/// Integration tests for property-level <c>textAnalyzer</c> configuration and
+/// collection-level <c>stopwordPresets</c>. Requires Weaviate ≥ 1.37.0.
+/// Ports <c>integration/test_collection_config.py</c> from weaviate-python-client PR #2006.
+/// </summary>
+[Collection("TestCollectionTextAnalyzer")]
+public class TestCollectionTextAnalyzer : IntegrationTests
+{
+    private const string MinVersion = "1.37.0";
+
+    // -----------------------------------------------------------------------
+    // Collection-level stopwordPresets
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task StopwordPresets_AppliedAndRoundTripped()
+    {
+        RequireVersion(MinVersion, message: "stopwordPresets requires Weaviate >= 1.37.0");
+
+        var collection = await CollectionFactory(
+            properties:
+            [
+                new Property
+                {
+                    Name = "title_fr",
+                    DataType = DataType.Text,
+                    PropertyTokenization = PropertyTokenization.Word,
+                    TextAnalyzer = new TextAnalyzerConfig { StopwordPreset = "fr" },
+                },
+                new Property
+                {
+                    Name = "title_en",
+                    DataType = DataType.Text,
+                    PropertyTokenization = PropertyTokenization.Word,
+                    TextAnalyzer = new TextAnalyzerConfig { StopwordPreset = "en" },
+                },
+                new Property
+                {
+                    Name = "plain",
+                    DataType = DataType.Text,
+                    PropertyTokenization = PropertyTokenization.Word,
+                },
+            ],
+            invertedIndexConfig: new()
+            {
+                StopwordPresets = new Dictionary<string, IList<string>>
+                {
+                    ["fr"] = new List<string> { "le", "la", "les" },
+                },
+            }
+        );
+
+        var config = await collection.Config.Get(TestContext.Current.CancellationToken);
+
+        Assert.NotNull(config.InvertedIndexConfig);
+        Assert.NotNull(config.InvertedIndexConfig!.StopwordPresets);
+        Assert.Equal(
+            new[] { "le", "la", "les" },
+            config.InvertedIndexConfig.StopwordPresets!["fr"]
+        );
+
+        var titleFr = config.Properties.Single(p => p.Name == "title_fr");
+        var titleEn = config.Properties.Single(p => p.Name == "title_en");
+        var plain = config.Properties.Single(p => p.Name == "plain");
+
+        Assert.NotNull(titleFr.TextAnalyzer);
+        Assert.Equal("fr", titleFr.TextAnalyzer!.StopwordPreset);
+        Assert.NotNull(titleEn.TextAnalyzer);
+        Assert.Equal("en", titleEn.TextAnalyzer!.StopwordPreset);
+        Assert.Null(plain.TextAnalyzer);
+    }
+
+    [Fact]
+    public async Task StopwordPresets_Update_ReplacesPreset()
+    {
+        RequireVersion(MinVersion, message: "stopwordPresets requires Weaviate >= 1.37.0");
+
+        var collection = await CollectionFactory(
+            properties:
+            [
+                new Property
+                {
+                    Name = "title_fr",
+                    DataType = DataType.Text,
+                    PropertyTokenization = PropertyTokenization.Word,
+                    TextAnalyzer = new TextAnalyzerConfig { StopwordPreset = "fr" },
+                },
+            ],
+            invertedIndexConfig: new()
+            {
+                StopwordPresets = new Dictionary<string, IList<string>>
+                {
+                    ["fr"] = new List<string> { "le" },
+                },
+            }
+        );
+
+        var config = await collection.Config.Get(TestContext.Current.CancellationToken);
+        Assert.Equal(new[] { "le" }, config.InvertedIndexConfig!.StopwordPresets!["fr"]);
+
+        await collection.Config.Update(
+            c =>
+            {
+                c.InvertedIndexConfig.StopwordPresets = new Dictionary<string, IList<string>>
+                {
+                    ["fr"] = new List<string> { "la" },
+                };
+            },
+            TestContext.Current.CancellationToken
+        );
+
+        config = await collection.Config.Get(TestContext.Current.CancellationToken);
+        Assert.Equal(new[] { "la" }, config.InvertedIndexConfig!.StopwordPresets!["fr"]);
+    }
+
+    [Fact]
+    public async Task StopwordPresets_RemoveInUse_RejectedByServer()
+    {
+        RequireVersion(MinVersion, message: "stopwordPresets requires Weaviate >= 1.37.0");
+
+        var collection = await CollectionFactory(
+            properties:
+            [
+                new Property
+                {
+                    Name = "title_fr",
+                    DataType = DataType.Text,
+                    PropertyTokenization = PropertyTokenization.Word,
+                    TextAnalyzer = new TextAnalyzerConfig { StopwordPreset = "fr" },
+                },
+            ],
+            invertedIndexConfig: new()
+            {
+                StopwordPresets = new Dictionary<string, IList<string>>
+                {
+                    ["fr"] = new List<string> { "le", "la", "les" },
+                },
+            }
+        );
+
+        await Assert.ThrowsAnyAsync<WeaviateClientException>(async () =>
+        {
+            await collection.Config.Update(
+                c =>
+                {
+                    c.InvertedIndexConfig.StopwordPresets = new Dictionary<string, IList<string>>();
+                },
+                TestContext.Current.CancellationToken
+            );
+        });
+
+        // The original preset must survive the rejected update.
+        var config = await collection.Config.Get(TestContext.Current.CancellationToken);
+        Assert.Equal(
+            new[] { "le", "la", "les" },
+            config.InvertedIndexConfig!.StopwordPresets!["fr"]
+        );
+    }
+
+    [Fact]
+    public async Task StopwordPresets_RemoveUnused_Allowed()
+    {
+        RequireVersion(MinVersion, message: "stopwordPresets requires Weaviate >= 1.37.0");
+
+        var collection = await CollectionFactory(
+            properties:
+            [
+                new Property
+                {
+                    Name = "title",
+                    DataType = DataType.Text,
+                    PropertyTokenization = PropertyTokenization.Word,
+                    TextAnalyzer = new TextAnalyzerConfig { StopwordPreset = "fr" },
+                },
+            ],
+            invertedIndexConfig: new()
+            {
+                StopwordPresets = new Dictionary<string, IList<string>>
+                {
+                    ["fr"] = new List<string> { "le", "la", "les" },
+                    ["es"] = new List<string> { "el", "la", "los" },
+                },
+            }
+        );
+
+        // Drop only 'es' (unused). 'fr' is still referenced by title.
+        await collection.Config.Update(
+            c =>
+            {
+                c.InvertedIndexConfig.StopwordPresets = new Dictionary<string, IList<string>>
+                {
+                    ["fr"] = new List<string> { "le", "la", "les" },
+                };
+            },
+            TestContext.Current.CancellationToken
+        );
+
+        var config = await collection.Config.Get(TestContext.Current.CancellationToken);
+        Assert.Equal(
+            new[] { "le", "la", "les" },
+            config.InvertedIndexConfig!.StopwordPresets!["fr"]
+        );
+        Assert.False(config.InvertedIndexConfig.StopwordPresets.ContainsKey("es"));
+    }
+
+    [Fact]
+    public async Task StopwordPresets_RemoveReferencedByNested_RejectedByServer()
+    {
+        RequireVersion(MinVersion, message: "stopwordPresets requires Weaviate >= 1.37.0");
+
+        var collection = await CollectionFactory(
+            properties:
+            [
+                new Property
+                {
+                    Name = "doc",
+                    DataType = DataType.Object,
+                    NestedProperties =
+                    [
+                        new Property
+                        {
+                            Name = "body",
+                            DataType = DataType.Text,
+                            PropertyTokenization = PropertyTokenization.Word,
+                            TextAnalyzer = new TextAnalyzerConfig { StopwordPreset = "fr" },
+                        },
+                    ],
+                },
+            ],
+            invertedIndexConfig: new()
+            {
+                StopwordPresets = new Dictionary<string, IList<string>>
+                {
+                    ["fr"] = new List<string> { "le", "la", "les" },
+                },
+            }
+        );
+
+        await Assert.ThrowsAnyAsync<WeaviateClientException>(async () =>
+        {
+            await collection.Config.Update(
+                c =>
+                {
+                    c.InvertedIndexConfig.StopwordPresets = new Dictionary<string, IList<string>>();
+                },
+                TestContext.Current.CancellationToken
+            );
+        });
+
+        var config = await collection.Config.Get(TestContext.Current.CancellationToken);
+        Assert.Equal(
+            new[] { "le", "la", "les" },
+            config.InvertedIndexConfig!.StopwordPresets!["fr"]
+        );
+    }
+
+    [Fact]
+    public async Task UserDefinedStopwordPreset_OverridesBuiltin()
+    {
+        RequireVersion(MinVersion, message: "stopwordPresets requires Weaviate >= 1.37.0");
+
+        var collection = await CollectionFactory(
+            properties:
+            [
+                new Property
+                {
+                    Name = "title",
+                    DataType = DataType.Text,
+                    PropertyTokenization = PropertyTokenization.Word,
+                    TextAnalyzer = new TextAnalyzerConfig { StopwordPreset = "en" },
+                },
+            ],
+            invertedIndexConfig: new()
+            {
+                StopwordPresets = new Dictionary<string, IList<string>>
+                {
+                    ["en"] = new List<string> { "hello" },
+                },
+            }
+        );
+
+        var config = await collection.Config.Get(TestContext.Current.CancellationToken);
+        Assert.Equal(new[] { "hello" }, config.InvertedIndexConfig!.StopwordPresets!["en"]);
+
+        var title = config.Properties.Single(p => p.Name == "title");
+        Assert.NotNull(title.TextAnalyzer);
+        Assert.Equal("en", title.TextAnalyzer!.StopwordPreset);
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-level TextAnalyzer
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task TextAnalyzer_CombinedAsciiFoldAndStopwordPreset()
+    {
+        RequireVersion(MinVersion, message: "textAnalyzer requires Weaviate >= 1.37.0");
+
+        var collection = await CollectionFactory(
+            properties:
+            [
+                new Property
+                {
+                    Name = "title",
+                    DataType = DataType.Text,
+                    PropertyTokenization = PropertyTokenization.Word,
+                    TextAnalyzer = new TextAnalyzerConfig
+                    {
+                        AsciiFold = new AsciiFoldConfig(),
+                        StopwordPreset = "en",
+                    },
+                },
+            ]
+        );
+
+        var config = await collection.Config.Get(TestContext.Current.CancellationToken);
+        var title = config.Properties.Single(p => p.Name == "title");
+
+        Assert.NotNull(title.TextAnalyzer);
+        Assert.NotNull(title.TextAnalyzer!.AsciiFold);
+        Assert.Equal("en", title.TextAnalyzer.StopwordPreset);
+    }
+
+    [Fact]
+    public async Task TextAnalyzer_AsciiFoldIgnore_RoundTrips()
+    {
+        RequireVersion(MinVersion, message: "textAnalyzer requires Weaviate >= 1.37.0");
+
+        var collection = await CollectionFactory(
+            properties:
+            [
+                new Property
+                {
+                    Name = "title",
+                    DataType = DataType.Text,
+                    PropertyTokenization = PropertyTokenization.Word,
+                    TextAnalyzer = new TextAnalyzerConfig
+                    {
+                        AsciiFold = new AsciiFoldConfig(Ignore: ["é"]),
+                    },
+                },
+            ]
+        );
+
+        var config = await collection.Config.Get(TestContext.Current.CancellationToken);
+        var title = config.Properties.Single(p => p.Name == "title");
+
+        Assert.NotNull(title.TextAnalyzer);
+        Assert.NotNull(title.TextAnalyzer!.AsciiFold);
+        Assert.Equal(new[] { "é" }, title.TextAnalyzer.AsciiFold!.Ignore);
+    }
+
+    [Fact]
+    public async Task TextAnalyzer_FullRoundTrip_FromDictStyleConfig()
+    {
+        RequireVersion(MinVersion, message: "textAnalyzer requires Weaviate >= 1.37.0");
+
+        var collection = await CollectionFactory(
+            properties:
+            [
+                new Property
+                {
+                    Name = "title",
+                    DataType = DataType.Text,
+                    PropertyTokenization = PropertyTokenization.Word,
+                    TextAnalyzer = new TextAnalyzerConfig
+                    {
+                        AsciiFold = new AsciiFoldConfig(Ignore: ["é"]),
+                        StopwordPreset = "fr",
+                    },
+                },
+            ],
+            invertedIndexConfig: new()
+            {
+                Stopwords = new StopwordConfig
+                {
+                    Preset = StopwordConfig.Presets.EN,
+                    Additions = ["a"],
+                    Removals = ["the"],
+                },
+                StopwordPresets = new Dictionary<string, IList<string>>
+                {
+                    ["fr"] = new List<string> { "le", "la", "les" },
+                },
+            }
+        );
+
+        var config = await collection.Config.Get(TestContext.Current.CancellationToken);
+
+        Assert.Equal(StopwordConfig.Presets.EN, config.InvertedIndexConfig!.Stopwords!.Preset);
+        Assert.Equal(new[] { "the" }, config.InvertedIndexConfig.Stopwords.Removals);
+        Assert.Equal(
+            new[] { "le", "la", "les" },
+            config.InvertedIndexConfig.StopwordPresets!["fr"]
+        );
+
+        var title = config.Properties.Single(p => p.Name == "title");
+        Assert.NotNull(title.TextAnalyzer);
+        Assert.Equal("fr", title.TextAnalyzer!.StopwordPreset);
+        Assert.NotNull(title.TextAnalyzer.AsciiFold);
+        Assert.Equal(new[] { "é" }, title.TextAnalyzer.AsciiFold!.Ignore);
+    }
+
+    // -----------------------------------------------------------------------
+    // Version-gate
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Property_TextAnalyzer_RaisesOnOldServer()
+    {
+        if (ServerVersionIsInRange(MinVersion))
+        {
+            Assert.Skip(
+                $"Version gate only applies to Weaviate < {MinVersion}. Current: {_weaviate.WeaviateVersion}"
+            );
+        }
+
+        await Assert.ThrowsAsync<WeaviateVersionMismatchException>(async () =>
+        {
+            await CollectionFactory(
+                properties:
+                [
+                    new Property
+                    {
+                        Name = "title",
+                        DataType = DataType.Text,
+                        PropertyTokenization = PropertyTokenization.Word,
+                        TextAnalyzer = new TextAnalyzerConfig { AsciiFold = new AsciiFoldConfig() },
+                    },
+                ]
+            );
+        });
+    }
+
+    [Fact]
+    public async Task InvertedIndexConfig_StopwordPresets_RaisesOnOldServer()
+    {
+        if (ServerVersionIsInRange(MinVersion))
+        {
+            Assert.Skip(
+                $"Version gate only applies to Weaviate < {MinVersion}. Current: {_weaviate.WeaviateVersion}"
+            );
+        }
+
+        await Assert.ThrowsAsync<WeaviateVersionMismatchException>(async () =>
+        {
+            await CollectionFactory(
+                invertedIndexConfig: new()
+                {
+                    StopwordPresets = new Dictionary<string, IList<string>>
+                    {
+                        ["fr"] = new List<string> { "le", "la" },
+                    },
+                }
+            );
+        });
+    }
+}

--- a/src/Weaviate.Client.Tests/Integration/TestCollectionTextAnalyzer.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestCollectionTextAnalyzer.cs
@@ -142,7 +142,7 @@ public class TestCollectionTextAnalyzer : IntegrationTests
             }
         );
 
-        await Assert.ThrowsAnyAsync<WeaviateClientException>(async () =>
+        await Assert.ThrowsAnyAsync<WeaviateUnprocessableEntityException>(async () =>
         {
             await collection.Config.Update(
                 c =>
@@ -240,7 +240,7 @@ public class TestCollectionTextAnalyzer : IntegrationTests
             }
         );
 
-        await Assert.ThrowsAnyAsync<WeaviateClientException>(async () =>
+        await Assert.ThrowsAnyAsync<WeaviateUnprocessableEntityException>(async () =>
         {
             await collection.Config.Update(
                 c =>

--- a/src/Weaviate.Client.Tests/Integration/TestTokenize.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestTokenize.cs
@@ -1,0 +1,285 @@
+using System.Collections.Immutable;
+using Weaviate.Client.Models;
+
+namespace Weaviate.Client.Tests.Integration;
+
+/// <summary>
+/// Integration tests for the <c>/v1/tokenize</c> and
+/// <c>/v1/schema/{className}/properties/{propertyName}/tokenize</c> endpoints.
+/// Requires Weaviate server version 1.37.0 or later.
+/// </summary>
+[Collection("TestTokenize")]
+public class TestTokenize : IntegrationTests
+{
+    // -----------------------------------------------------------------------
+    // Serialization
+    // -----------------------------------------------------------------------
+
+    public static TheoryData<PropertyTokenization, string, string[]> TokenizationCases =>
+        new()
+        {
+            {
+                PropertyTokenization.Word,
+                "The quick brown fox",
+                new[] { "the", "quick", "brown", "fox" }
+            },
+            {
+                PropertyTokenization.Lowercase,
+                "Hello World Test",
+                new[] { "hello", "world", "test" }
+            },
+            {
+                PropertyTokenization.Whitespace,
+                "Hello World Test",
+                new[] { "Hello", "World", "Test" }
+            },
+            { PropertyTokenization.Field, "  Hello World  ", new[] { "Hello World" } },
+            { PropertyTokenization.Trigram, "Hello", new[] { "hel", "ell", "llo" } },
+        };
+
+    [Theory]
+    [MemberData(nameof(TokenizationCases))]
+    public async Task Tokenization_Enum(
+        PropertyTokenization tokenization,
+        string text,
+        string[] expectedTokens
+    )
+    {
+        RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
+
+        var result = await _weaviate.Tokenize.Text(
+            text,
+            tokenization,
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(tokenization, result.Tokenization);
+        Assert.Equal(expectedTokens, result.Indexed);
+        Assert.Equal(expectedTokens, result.Query);
+    }
+
+    [Fact]
+    public async Task NoAnalyzerConfig()
+    {
+        RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
+
+        var result = await _weaviate.Tokenize.Text(
+            "hello world",
+            PropertyTokenization.Word,
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(PropertyTokenization.Word, result.Tokenization);
+        Assert.Equal(new[] { "hello", "world" }, result.Indexed);
+        Assert.Null(result.AnalyzerConfig);
+    }
+
+    [Fact]
+    public async Task AsciiFold()
+    {
+        RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
+
+        var cfg = new TokenizeAnalyzerConfig { AsciiFold = new AsciiFoldConfig() };
+        var result = await _weaviate.Tokenize.Text(
+            "L'école est fermée",
+            PropertyTokenization.Word,
+            analyzerConfig: cfg,
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(new[] { "l", "ecole", "est", "fermee" }, result.Indexed);
+    }
+
+    [Fact]
+    public async Task AsciiFold_WithIgnore()
+    {
+        RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
+
+        var cfg = new TokenizeAnalyzerConfig { AsciiFold = new AsciiFoldConfig(Ignore: ["é"]) };
+        var result = await _weaviate.Tokenize.Text(
+            "L'école est fermée",
+            PropertyTokenization.Word,
+            analyzerConfig: cfg,
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(new[] { "l", "école", "est", "fermée" }, result.Indexed);
+    }
+
+    [Fact]
+    public async Task StopwordPreset_String()
+    {
+        RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
+
+        var cfg = new TokenizeAnalyzerConfig { StopwordPreset = "en" };
+        var result = await _weaviate.Tokenize.Text(
+            "The quick brown fox",
+            PropertyTokenization.Word,
+            analyzerConfig: cfg,
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        Assert.DoesNotContain("the", result.Query);
+        Assert.Contains("quick", result.Query);
+    }
+
+    [Fact]
+    public async Task Combined_AsciiFold_Stopwords()
+    {
+        RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
+
+        var cfg = new TokenizeAnalyzerConfig
+        {
+            AsciiFold = new AsciiFoldConfig(Ignore: ["é"]),
+            StopwordPreset = "en",
+        };
+        var result = await _weaviate.Tokenize.Text(
+            "The école est fermée",
+            PropertyTokenization.Word,
+            analyzerConfig: cfg,
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(new[] { "the", "école", "est", "fermée" }, result.Indexed);
+        Assert.DoesNotContain("the", result.Query);
+        Assert.Contains("école", result.Query);
+    }
+
+    [Fact]
+    public async Task CustomPreset_Additions()
+    {
+        RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
+
+        var cfg = new TokenizeAnalyzerConfig { StopwordPreset = "custom" };
+        var presets = new Dictionary<string, StopwordConfig>
+        {
+            ["custom"] = new StopwordConfig
+            {
+                Preset = StopwordConfig.Presets.None,
+                Additions = ["test"],
+            },
+        };
+
+        var result = await _weaviate.Tokenize.Text(
+            "hello world test",
+            PropertyTokenization.Word,
+            analyzerConfig: cfg,
+            stopwordPresets: presets,
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(new[] { "hello", "world", "test" }, result.Indexed);
+        Assert.Equal(new[] { "hello", "world" }, result.Query);
+    }
+
+    [Fact]
+    public async Task CustomPreset_BaseAndRemovals()
+    {
+        RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
+
+        var cfg = new TokenizeAnalyzerConfig { StopwordPreset = "en-no-the" };
+        var presets = new Dictionary<string, StopwordConfig>
+        {
+            ["en-no-the"] = new StopwordConfig
+            {
+                Preset = StopwordConfig.Presets.EN,
+                Removals = ["the"],
+            },
+        };
+
+        var result = await _weaviate.Tokenize.Text(
+            "the quick",
+            PropertyTokenization.Word,
+            analyzerConfig: cfg,
+            stopwordPresets: presets,
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(new[] { "the", "quick" }, result.Indexed);
+        Assert.Equal(new[] { "the", "quick" }, result.Query);
+    }
+
+    // -----------------------------------------------------------------------
+    // Deserialization
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Result_Types()
+    {
+        RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
+
+        var result = await _weaviate.Tokenize.Text(
+            "hello",
+            PropertyTokenization.Word,
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        Assert.IsType<TokenizeResult>(result);
+        Assert.IsType<ImmutableList<string>>(result.Indexed);
+        Assert.IsType<ImmutableList<string>>(result.Query);
+    }
+
+    [Fact]
+    public async Task AnalyzerConfig_Echoed()
+    {
+        RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
+
+        var cfg = new TokenizeAnalyzerConfig
+        {
+            AsciiFold = new AsciiFoldConfig(Ignore: ["é"]),
+            StopwordPreset = "en",
+        };
+        var result = await _weaviate.Tokenize.Text(
+            "L'école",
+            PropertyTokenization.Word,
+            analyzerConfig: cfg,
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        Assert.NotNull(result.AnalyzerConfig);
+        Assert.NotNull(result.AnalyzerConfig!.AsciiFold);
+        Assert.Equal(new[] { "é" }, result.AnalyzerConfig.AsciiFold!.Ignore);
+        Assert.Equal("en", result.AnalyzerConfig.StopwordPreset);
+    }
+
+    [Fact]
+    public async Task AnalyzerConfig_None()
+    {
+        RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
+
+        var result = await _weaviate.Tokenize.Text(
+            "hello",
+            PropertyTokenization.Word,
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        Assert.Null(result.AnalyzerConfig);
+    }
+
+    [Fact]
+    public async Task PropertyTokenize_Field()
+    {
+        RequireVersion<CollectionTokenizeClient>(nameof(CollectionTokenizeClient.Property));
+
+        var collection = await CollectionFactory(
+            properties:
+            [
+                new Property
+                {
+                    Name = "tag",
+                    DataType = DataType.Text,
+                    PropertyTokenization = PropertyTokenization.Field,
+                },
+            ]
+        );
+
+        var result = await collection.Tokenize.Property(
+            "tag",
+            "  Hello World  ",
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(PropertyTokenization.Field, result.Tokenization);
+        Assert.Equal(new[] { "Hello World" }, result.Indexed);
+    }
+}

--- a/src/Weaviate.Client.Tests/Integration/TestTokenize.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestTokenize.cs
@@ -47,9 +47,13 @@ public class TestTokenize : IntegrationTests
     {
         RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
 
+        // Disable stopwords explicitly: when no stopwords config is supplied,
+        // the server defaults Word tokenization to the EN preset, which strips
+        // "the" from result.Query and would break the assertion below.
         var result = await _weaviate.Tokenize.Text(
             text,
             tokenization,
+            stopwords: new StopwordConfig { Preset = StopwordConfig.Presets.None },
             cancellationToken: TestContext.Current.CancellationToken
         );
 

--- a/src/Weaviate.Client.Tests/Integration/TestTokenize.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestTokenize.cs
@@ -79,7 +79,7 @@ public class TestTokenize : IntegrationTests
     {
         RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
 
-        var cfg = new TokenizeAnalyzerConfig { AsciiFold = new AsciiFoldConfig() };
+        var cfg = new TextAnalyzerConfig { AsciiFold = new AsciiFoldConfig() };
         var result = await _weaviate.Tokenize.Text(
             "L'école est fermée",
             PropertyTokenization.Word,
@@ -95,7 +95,7 @@ public class TestTokenize : IntegrationTests
     {
         RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
 
-        var cfg = new TokenizeAnalyzerConfig { AsciiFold = new AsciiFoldConfig(Ignore: ["é"]) };
+        var cfg = new TextAnalyzerConfig { AsciiFold = new AsciiFoldConfig(Ignore: ["é"]) };
         var result = await _weaviate.Tokenize.Text(
             "L'école est fermée",
             PropertyTokenization.Word,
@@ -111,7 +111,7 @@ public class TestTokenize : IntegrationTests
     {
         RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
 
-        var cfg = new TokenizeAnalyzerConfig { StopwordPreset = "en" };
+        var cfg = new TextAnalyzerConfig { StopwordPreset = "en" };
         var result = await _weaviate.Tokenize.Text(
             "The quick brown fox",
             PropertyTokenization.Word,
@@ -128,7 +128,7 @@ public class TestTokenize : IntegrationTests
     {
         RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
 
-        var cfg = new TokenizeAnalyzerConfig
+        var cfg = new TextAnalyzerConfig
         {
             AsciiFold = new AsciiFoldConfig(Ignore: ["é"]),
             StopwordPreset = "en",
@@ -150,7 +150,7 @@ public class TestTokenize : IntegrationTests
     {
         RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
 
-        var cfg = new TokenizeAnalyzerConfig { StopwordPreset = "custom" };
+        var cfg = new TextAnalyzerConfig { StopwordPreset = "custom" };
         var presets = new Dictionary<string, StopwordConfig>
         {
             ["custom"] = new StopwordConfig
@@ -177,7 +177,7 @@ public class TestTokenize : IntegrationTests
     {
         RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
 
-        var cfg = new TokenizeAnalyzerConfig { StopwordPreset = "en-no-the" };
+        var cfg = new TextAnalyzerConfig { StopwordPreset = "en-no-the" };
         var presets = new Dictionary<string, StopwordConfig>
         {
             ["en-no-the"] = new StopwordConfig
@@ -224,7 +224,7 @@ public class TestTokenize : IntegrationTests
     {
         RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
 
-        var cfg = new TokenizeAnalyzerConfig
+        var cfg = new TextAnalyzerConfig
         {
             AsciiFold = new AsciiFoldConfig(Ignore: ["é"]),
             StopwordPreset = "en",

--- a/src/Weaviate.Client.Tests/Integration/TestTokenize.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestTokenize.cs
@@ -53,7 +53,6 @@ public class TestTokenize : IntegrationTests
             cancellationToken: TestContext.Current.CancellationToken
         );
 
-        Assert.Equal(tokenization, result.Tokenization);
         Assert.Equal(expectedTokens, result.Indexed);
         Assert.Equal(expectedTokens, result.Query);
     }
@@ -69,9 +68,7 @@ public class TestTokenize : IntegrationTests
             cancellationToken: TestContext.Current.CancellationToken
         );
 
-        Assert.Equal(PropertyTokenization.Word, result.Tokenization);
         Assert.Equal(new[] { "hello", "world" }, result.Indexed);
-        Assert.Null(result.AnalyzerConfig);
     }
 
     [Fact]
@@ -151,14 +148,7 @@ public class TestTokenize : IntegrationTests
         RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
 
         var cfg = new TextAnalyzerConfig { StopwordPreset = "custom" };
-        var presets = new Dictionary<string, StopwordConfig>
-        {
-            ["custom"] = new StopwordConfig
-            {
-                Preset = StopwordConfig.Presets.None,
-                Additions = ["test"],
-            },
-        };
+        var presets = new Dictionary<string, IList<string>> { ["custom"] = ["test"] };
 
         var result = await _weaviate.Tokenize.Text(
             "hello world test",
@@ -173,25 +163,19 @@ public class TestTokenize : IntegrationTests
     }
 
     [Fact]
-    public async Task CustomPreset_BaseAndRemovals()
+    public async Task Stopwords_OneOff_BaseAndRemovals()
     {
         RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
 
-        var cfg = new TextAnalyzerConfig { StopwordPreset = "en-no-the" };
-        var presets = new Dictionary<string, StopwordConfig>
-        {
-            ["en-no-the"] = new StopwordConfig
+        // Use the one-off stopwords block: start from EN preset, remove "the" so it is not filtered.
+        var result = await _weaviate.Tokenize.Text(
+            "the quick",
+            PropertyTokenization.Word,
+            stopwords: new StopwordConfig
             {
                 Preset = StopwordConfig.Presets.EN,
                 Removals = ["the"],
             },
-        };
-
-        var result = await _weaviate.Tokenize.Text(
-            "the quick",
-            PropertyTokenization.Word,
-            analyzerConfig: cfg,
-            stopwordPresets: presets,
             cancellationToken: TestContext.Current.CancellationToken
         );
 
@@ -220,43 +204,6 @@ public class TestTokenize : IntegrationTests
     }
 
     [Fact]
-    public async Task AnalyzerConfig_Echoed()
-    {
-        RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
-
-        var cfg = new TextAnalyzerConfig
-        {
-            AsciiFold = new AsciiFoldConfig(Ignore: ["é"]),
-            StopwordPreset = "en",
-        };
-        var result = await _weaviate.Tokenize.Text(
-            "L'école",
-            PropertyTokenization.Word,
-            analyzerConfig: cfg,
-            cancellationToken: TestContext.Current.CancellationToken
-        );
-
-        Assert.NotNull(result.AnalyzerConfig);
-        Assert.NotNull(result.AnalyzerConfig!.AsciiFold);
-        Assert.Equal(new[] { "é" }, result.AnalyzerConfig.AsciiFold!.Ignore);
-        Assert.Equal("en", result.AnalyzerConfig.StopwordPreset);
-    }
-
-    [Fact]
-    public async Task AnalyzerConfig_None()
-    {
-        RequireVersion<TokenizeClient>(nameof(TokenizeClient.Text));
-
-        var result = await _weaviate.Tokenize.Text(
-            "hello",
-            PropertyTokenization.Word,
-            cancellationToken: TestContext.Current.CancellationToken
-        );
-
-        Assert.Null(result.AnalyzerConfig);
-    }
-
-    [Fact]
     public async Task PropertyTokenize_Field()
     {
         RequireVersion<CollectionTokenizeClient>(nameof(CollectionTokenizeClient.Property));
@@ -279,7 +226,6 @@ public class TestTokenize : IntegrationTests
             TestContext.Current.CancellationToken
         );
 
-        Assert.Equal(PropertyTokenization.Field, result.Tokenization);
         Assert.Equal(new[] { "Hello World" }, result.Indexed);
     }
 }

--- a/src/Weaviate.Client/CollectionClient.cs
+++ b/src/Weaviate.Client/CollectionClient.cs
@@ -232,4 +232,10 @@ public partial class CollectionClient
     /// Gets the configuration client for managing collection configuration.
     /// </summary>
     public CollectionConfigClient Config => new(Client, Name);
+
+    /// <summary>
+    /// Gets the tokenize client for inspecting how text is tokenized by
+    /// properties of this collection. Requires Weaviate server version 1.37.0 or later.
+    /// </summary>
+    public CollectionTokenizeClient Tokenize => new(Client, Name);
 }

--- a/src/Weaviate.Client/CollectionTokenizeClient.cs
+++ b/src/Weaviate.Client/CollectionTokenizeClient.cs
@@ -1,0 +1,58 @@
+using Weaviate.Client.Models;
+
+namespace Weaviate.Client;
+
+/// <summary>
+/// Exposes the per-property <c>/v1/schema/{className}/properties/{propertyName}/tokenize</c>
+/// endpoint for a specific collection. Requires Weaviate server version 1.37.0 or later.
+/// </summary>
+public sealed class CollectionTokenizeClient
+{
+    private readonly WeaviateClient _client;
+    private readonly string _collectionName;
+
+    internal CollectionTokenizeClient(WeaviateClient client, string collectionName)
+    {
+        _client = client;
+        _collectionName = collectionName;
+    }
+
+    /// <summary>
+    /// Tokenizes <paramref name="text"/> using the tokenization method configured on
+    /// property <paramref name="propertyName"/> of this collection.
+    /// </summary>
+    /// <param name="propertyName">The name of the property whose tokenization to apply.</param>
+    /// <param name="text">The text to tokenize.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The tokenization result.</returns>
+    /// <exception cref="WeaviateVersionMismatchException">
+    /// Thrown when the connected server version is below 1.37.0.
+    /// </exception>
+    [RequiresWeaviateVersion(1, 37, 0)]
+    public async Task<TokenizeResult> Property(
+        string propertyName,
+        string text,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentException.ThrowIfNullOrEmpty(propertyName);
+        ArgumentNullException.ThrowIfNull(text);
+
+        await _client.EnsureVersion<CollectionTokenizeClient>();
+
+        var response =
+            await _client.RestClient.TokenizeProperty(
+                _collectionName,
+                propertyName,
+                new Rest.Dto.PropertyTokenizeRequest { Text = text },
+                cancellationToken
+            )
+            ?? throw new WeaviateClientException(
+                new InvalidOperationException(
+                    "Tokenize property endpoint returned an empty response."
+                )
+            );
+
+        return response.ToModel();
+    }
+}

--- a/src/Weaviate.Client/CollectionsClient.cs
+++ b/src/Weaviate.Client/CollectionsClient.cs
@@ -197,6 +197,8 @@ public record CollectionsClient
     {
         ArgumentNullException.ThrowIfNull(collection);
 
+        await EnsureTextAnalyzerFeaturesSupported(collection);
+
         var config = CollectionConfig.FromCollectionCreate(collection);
 
         var jsonString = JsonSerializer.Serialize(
@@ -205,6 +207,59 @@ public record CollectionsClient
         );
 
         return await CreateFromJson(jsonString, cancellationToken);
+    }
+
+    private static readonly Version TextAnalyzerMinimumVersion = new(1, 37, 0);
+
+    private async Task EnsureTextAnalyzerFeaturesSupported(CollectionCreateParams collection)
+    {
+        string? feature = DetectTextAnalyzerFeature(collection);
+        if (feature is null)
+            return;
+
+        await _client.EnsureInitializedAsync();
+
+        var serverVersion = _client.WeaviateVersion;
+        if (serverVersion is null)
+            return;
+
+        if (serverVersion < TextAnalyzerMinimumVersion)
+        {
+            throw new WeaviateVersionMismatchException(
+                feature,
+                TextAnalyzerMinimumVersion,
+                serverVersion
+            );
+        }
+    }
+
+    private static string? DetectTextAnalyzerFeature(CollectionCreateParams collection)
+    {
+        if (collection.InvertedIndexConfig?.StopwordPresets is { Count: > 0 })
+            return "InvertedIndexConfig.StopwordPresets";
+
+        foreach (var property in collection.Properties)
+        {
+            if (PropertyUsesTextAnalyzer(property))
+                return "Property.TextAnalyzer";
+        }
+
+        return null;
+    }
+
+    private static bool PropertyUsesTextAnalyzer(Property property)
+    {
+        if (property.TextAnalyzer is not null)
+            return true;
+        if (property.NestedProperties is { } nested)
+        {
+            foreach (var np in nested)
+            {
+                if (PropertyUsesTextAnalyzer(np))
+                    return true;
+            }
+        }
+        return false;
     }
 
     /// <summary>

--- a/src/Weaviate.Client/Extensions.cs
+++ b/src/Weaviate.Client/Extensions.cs
@@ -242,6 +242,7 @@ public static class WeaviateExtensions
                         ? collection.InvertedIndexConfig.IndexTimestamps
                         : null,
                 UsingBlockMaxWAND = collection.InvertedIndexConfig.UsingBlockMaxWAND,
+                StopwordPresets = collection.InvertedIndexConfig.StopwordPresets,
             };
         }
 
@@ -352,6 +353,7 @@ public static class WeaviateExtensions
                         ?? Weaviate.Client.Models.InvertedIndexConfig.Default.IndexTimestamps,
 
                     UsingBlockMaxWAND = iic.UsingBlockMaxWAND,
+                    StopwordPresets = iic.StopwordPresets,
                 }
                 : null;
 

--- a/src/Weaviate.Client/Models/Collection.Update.cs
+++ b/src/Weaviate.Client/Models/Collection.Update.cs
@@ -123,6 +123,17 @@ public record InvertedIndexConfigUpdate(InvertedIndexConfig WrappedConfig)
     /// </summary>
     public StopwordsConfigUpdate Stopwords =>
         new(WrappedConfig.Stopwords ??= StopwordConfig.Default);
+
+    /// <summary>
+    /// Gets or sets the named stopword presets defined at the collection level.
+    /// Setting this replaces the full preset map on the server.
+    /// Requires Weaviate ≥ 1.37.0.
+    /// </summary>
+    public IDictionary<string, IList<string>>? StopwordPresets
+    {
+        get => WrappedConfig.StopwordPresets;
+        set => WrappedConfig.StopwordPresets = value;
+    }
 }
 
 /// <summary>

--- a/src/Weaviate.Client/Models/Extensions.cs
+++ b/src/Weaviate.Client/Models/Extensions.cs
@@ -57,6 +57,7 @@ internal static class ModelsToDtoExtensions
             NestedProperties = property
                 .NestedProperties?.Select(np => np.ToNestedPropertyDto())
                 .ToList(),
+            TextAnalyzer = property.TextAnalyzer.ToDto(),
         };
     }
 
@@ -122,6 +123,7 @@ internal static class ModelsToDtoExtensions
                 .NestedProperties?.Select(np => np.ToNestedPropertyDto())
                 .ToList(),
             ModuleConfig = moduleConfig,
+            TextAnalyzer = property.TextAnalyzer.ToDto(),
         };
     }
 }

--- a/src/Weaviate.Client/Models/InvertedIndexConfig.cs
+++ b/src/Weaviate.Client/Models/InvertedIndexConfig.cs
@@ -52,6 +52,14 @@ public record InvertedIndexConfig : IEquatable<InvertedIndexConfig>
     public bool? UsingBlockMaxWAND { get; set; } = null;
 
     /// <summary>
+    /// Optional named stopword presets defined at the collection level.
+    /// Each entry is a preset name → list of stopwords. Individual properties
+    /// can reference a preset via <see cref="TextAnalyzerConfig.StopwordPreset"/>.
+    /// Requires Weaviate ≥ 1.37.0.
+    /// </summary>
+    public IDictionary<string, IList<string>>? StopwordPresets { get; set; } = null;
+
+    /// <summary>
     /// Gets the hash code
     /// </summary>
     /// <returns>The int</returns>
@@ -65,6 +73,15 @@ public record InvertedIndexConfig : IEquatable<InvertedIndexConfig>
         hash.Add(IndexTimestamps);
         hash.Add(Stopwords?.GetHashCode() ?? 0);
         hash.Add(UsingBlockMaxWAND);
+        if (StopwordPresets is not null)
+        {
+            foreach (var kvp in StopwordPresets.OrderBy(kvp => kvp.Key, StringComparer.Ordinal))
+            {
+                hash.Add(kvp.Key);
+                foreach (var word in kvp.Value)
+                    hash.Add(word);
+            }
+        }
         return hash.ToHashCode();
     }
 
@@ -106,6 +123,30 @@ public record InvertedIndexConfig : IEquatable<InvertedIndexConfig>
         )
             return false;
 
+        if (!StopwordPresetsEqual(StopwordPresets, other.StopwordPresets))
+            return false;
+
+        return true;
+    }
+
+    private static bool StopwordPresetsEqual(
+        IDictionary<string, IList<string>>? a,
+        IDictionary<string, IList<string>>? b
+    )
+    {
+        if (ReferenceEquals(a, b))
+            return true;
+        if (a is null || b is null)
+            return false;
+        if (a.Count != b.Count)
+            return false;
+        foreach (var kvp in a)
+        {
+            if (!b.TryGetValue(kvp.Key, out var otherValue))
+                return false;
+            if (!kvp.Value.SequenceEqual(otherValue))
+                return false;
+        }
         return true;
     }
 }

--- a/src/Weaviate.Client/Models/Property.cs
+++ b/src/Weaviate.Client/Models/Property.cs
@@ -606,6 +606,13 @@ public record Property : IEquatable<Property>
     /// </summary>
     public bool VectorizePropertyName { get; init; } = true;
 
+    /// <summary>
+    /// Optional property-level text analyzer configuration. When set, the property's
+    /// indexed and query tokens are post-processed according to the configured
+    /// ASCII-folding and stopword preset. Requires Weaviate ≥ 1.37.0.
+    /// </summary>
+    public TextAnalyzerConfig? TextAnalyzer { get; init; }
+
     /// <summary>Gets a factory for creating text properties.</summary>
     public static PropertyFactory Text => PropertyHelper.Factory(DataType.Text);
 
@@ -795,6 +802,7 @@ public record Property : IEquatable<Property>
         hash.Add(NestedProperties);
         hash.Add(SkipVectorization);
         hash.Add(VectorizePropertyName);
+        hash.Add(TextAnalyzer);
         return hash.ToHashCode();
     }
 
@@ -820,6 +828,10 @@ public record Property : IEquatable<Property>
             && PropertyTokenization == other.PropertyTokenization
             && SkipVectorization == other.SkipVectorization
             && VectorizePropertyName == other.VectorizePropertyName
+            && EqualityComparer<TextAnalyzerConfig?>.Default.Equals(
+                TextAnalyzer,
+                other.TextAnalyzer
+            )
             && (
                 (NestedProperties == null && other.NestedProperties == null)
                 || (

--- a/src/Weaviate.Client/Models/Tokenize.cs
+++ b/src/Weaviate.Client/Models/Tokenize.cs
@@ -5,7 +5,7 @@ namespace Weaviate.Client.Models;
 /// <summary>
 /// ASCII-folding configuration: enables accent/diacritic folding, with an
 /// optional list of characters to exclude. When set on
-/// <see cref="TokenizeAnalyzerConfig.AsciiFold"/>, folding is applied; when
+/// <see cref="TextAnalyzerConfig.AsciiFold"/>, folding is applied; when
 /// null, folding is disabled.
 /// </summary>
 /// <param name="Ignore">
@@ -17,7 +17,7 @@ public sealed record AsciiFoldConfig(IReadOnlyList<string>? Ignore = null);
 /// Optional text-analyzer configuration for the tokenize endpoint.
 /// Mirrors the server's <c>TextAnalyzerConfig</c>.
 /// </summary>
-public sealed record TokenizeAnalyzerConfig
+public sealed record TextAnalyzerConfig
 {
     /// <summary>
     /// ASCII-folding configuration. When non-null, accent/diacritic marks are
@@ -30,7 +30,7 @@ public sealed record TokenizeAnalyzerConfig
     /// <summary>
     /// Stopword preset name. May be a built-in preset (<c>"en"</c>, <c>"none"</c>)
     /// or the name of a custom preset provided via
-    /// <see cref="TokenizeClient.Text(string, PropertyTokenization, TokenizeAnalyzerConfig?, System.Collections.Generic.IDictionary{string, StopwordConfig}?, System.Threading.CancellationToken)"/>'s
+    /// <see cref="TokenizeClient.Text(string, PropertyTokenization, TextAnalyzerConfig?, System.Collections.Generic.IDictionary{string, StopwordConfig}?, System.Threading.CancellationToken)"/>'s
     /// <c>stopwordPresets</c> dictionary.
     /// </summary>
     public string? StopwordPreset { get; init; }
@@ -59,7 +59,7 @@ public sealed record TokenizeResult
     /// <summary>
     /// The text-analyzer configuration that was applied, if any.
     /// </summary>
-    public TokenizeAnalyzerConfig? AnalyzerConfig { get; init; }
+    public TextAnalyzerConfig? AnalyzerConfig { get; init; }
 
     /// <summary>
     /// The stopword configuration that was applied, if any.
@@ -80,7 +80,7 @@ internal static class TokenizeMapping
             ? PropertyTokenization.Word
             : wireValue.FromEnumMemberString<PropertyTokenization>();
 
-    internal static Rest.Dto.TextAnalyzerConfig? ToDto(this TokenizeAnalyzerConfig? config) =>
+    internal static Rest.Dto.TextAnalyzerConfig? ToDto(this TextAnalyzerConfig? config) =>
         config is null
             ? null
             : new Rest.Dto.TextAnalyzerConfig
@@ -92,10 +92,10 @@ internal static class TokenizeMapping
                 StopwordPreset = config.StopwordPreset,
             };
 
-    internal static TokenizeAnalyzerConfig? ToModel(this Rest.Dto.TextAnalyzerConfig? dto) =>
+    internal static TextAnalyzerConfig? ToModel(this Rest.Dto.TextAnalyzerConfig? dto) =>
         dto is null
             ? null
-            : new TokenizeAnalyzerConfig
+            : new TextAnalyzerConfig
             {
                 AsciiFold =
                     dto.AsciiFold == true

--- a/src/Weaviate.Client/Models/Tokenize.cs
+++ b/src/Weaviate.Client/Models/Tokenize.cs
@@ -1,0 +1,138 @@
+using System.Collections.Immutable;
+
+namespace Weaviate.Client.Models;
+
+/// <summary>
+/// ASCII-folding configuration: enables accent/diacritic folding, with an
+/// optional list of characters to exclude. When set on
+/// <see cref="TokenizeAnalyzerConfig.AsciiFold"/>, folding is applied; when
+/// null, folding is disabled.
+/// </summary>
+/// <param name="Ignore">
+/// Optional list of characters that should be excluded from ASCII folding.
+/// </param>
+public sealed record AsciiFoldConfig(IReadOnlyList<string>? Ignore = null);
+
+/// <summary>
+/// Optional text-analyzer configuration for the tokenize endpoint.
+/// Mirrors the server's <c>TextAnalyzerConfig</c>.
+/// </summary>
+public sealed record TokenizeAnalyzerConfig
+{
+    /// <summary>
+    /// ASCII-folding configuration. When non-null, accent/diacritic marks are
+    /// folded to their base characters (e.g. 'école' → 'ecole'), except for
+    /// characters listed in <see cref="AsciiFoldConfig.Ignore"/>.
+    /// When null, folding is disabled.
+    /// </summary>
+    public AsciiFoldConfig? AsciiFold { get; init; }
+
+    /// <summary>
+    /// Stopword preset name. May be a built-in preset (<c>"en"</c>, <c>"none"</c>)
+    /// or the name of a custom preset provided via
+    /// <see cref="TokenizeClient.Text(string, PropertyTokenization, TokenizeAnalyzerConfig?, System.Collections.Generic.IDictionary{string, StopwordConfig}?, System.Threading.CancellationToken)"/>'s
+    /// <c>stopwordPresets</c> dictionary.
+    /// </summary>
+    public string? StopwordPreset { get; init; }
+}
+
+/// <summary>
+/// Result of a tokenize request.
+/// </summary>
+public sealed record TokenizeResult
+{
+    /// <summary>
+    /// The tokenization method that was applied.
+    /// </summary>
+    public PropertyTokenization Tokenization { get; init; }
+
+    /// <summary>
+    /// Tokens as they are stored in the inverted index.
+    /// </summary>
+    public ImmutableList<string> Indexed { get; init; } = [];
+
+    /// <summary>
+    /// Tokens as they are used for query matching (after stopword removal, etc.).
+    /// </summary>
+    public ImmutableList<string> Query { get; init; } = [];
+
+    /// <summary>
+    /// The text-analyzer configuration that was applied, if any.
+    /// </summary>
+    public TokenizeAnalyzerConfig? AnalyzerConfig { get; init; }
+
+    /// <summary>
+    /// The stopword configuration that was applied, if any.
+    /// </summary>
+    public StopwordConfig? StopwordConfig { get; init; }
+}
+
+/// <summary>
+/// Mapping helpers between public tokenize models and generated DTOs.
+/// </summary>
+internal static class TokenizeMapping
+{
+    internal static Rest.Dto.TokenizeRequestTokenization ToDto(this PropertyTokenization value) =>
+        (Rest.Dto.TokenizeRequestTokenization)(int)value;
+
+    internal static PropertyTokenization ToTokenization(string? wireValue) =>
+        string.IsNullOrEmpty(wireValue)
+            ? PropertyTokenization.Word
+            : wireValue.FromEnumMemberString<PropertyTokenization>();
+
+    internal static Rest.Dto.TextAnalyzerConfig? ToDto(this TokenizeAnalyzerConfig? config) =>
+        config is null
+            ? null
+            : new Rest.Dto.TextAnalyzerConfig
+            {
+                AsciiFold = config.AsciiFold is not null ? true : null,
+                AsciiFoldIgnore = config.AsciiFold?.Ignore is { Count: > 0 } ignore
+                    ? [.. ignore]
+                    : null,
+                StopwordPreset = config.StopwordPreset,
+            };
+
+    internal static TokenizeAnalyzerConfig? ToModel(this Rest.Dto.TextAnalyzerConfig? dto) =>
+        dto is null
+            ? null
+            : new TokenizeAnalyzerConfig
+            {
+                AsciiFold =
+                    dto.AsciiFold == true
+                        ? new AsciiFoldConfig(
+                            dto.AsciiFoldIgnore is { Count: > 0 } ignore ? [.. ignore] : null
+                        )
+                        : null,
+                StopwordPreset = dto.StopwordPreset,
+            };
+
+    internal static Rest.Dto.StopwordConfig ToDto(this StopwordConfig config) =>
+        new()
+        {
+            Preset = config.Preset.ToEnumMemberString(),
+            Additions = config.Additions.Count > 0 ? [.. config.Additions] : null,
+            Removals = config.Removals.Count > 0 ? [.. config.Removals] : null,
+        };
+
+    internal static StopwordConfig? ToModel(this Rest.Dto.StopwordConfig? dto) =>
+        dto is null
+            ? null
+            : new StopwordConfig
+            {
+                Preset = string.IsNullOrEmpty(dto.Preset)
+                    ? StopwordConfig.Presets.None
+                    : dto.Preset.FromEnumMemberString<StopwordConfig.Presets>(),
+                Additions = dto.Additions?.ToImmutableList() ?? [],
+                Removals = dto.Removals?.ToImmutableList() ?? [],
+            };
+
+    internal static TokenizeResult ToModel(this Rest.Dto.TokenizeResponse dto) =>
+        new()
+        {
+            Tokenization = ToTokenization(dto.Tokenization),
+            Indexed = dto.Indexed?.ToImmutableList() ?? [],
+            Query = dto.Query?.ToImmutableList() ?? [],
+            AnalyzerConfig = dto.AnalyzerConfig.ToModel(),
+            StopwordConfig = dto.StopwordConfig.ToModel(),
+        };
+}

--- a/src/Weaviate.Client/Models/Tokenize.cs
+++ b/src/Weaviate.Client/Models/Tokenize.cs
@@ -29,9 +29,8 @@ public sealed record TextAnalyzerConfig
 
     /// <summary>
     /// Stopword preset name. May be a built-in preset (<c>"en"</c>, <c>"none"</c>)
-    /// or the name of a custom preset provided via
-    /// <see cref="TokenizeClient.Text(string, PropertyTokenization, TextAnalyzerConfig?, System.Collections.Generic.IDictionary{string, StopwordConfig}?, System.Threading.CancellationToken)"/>'s
-    /// <c>stopwordPresets</c> dictionary.
+    /// or the name of a custom preset provided via the
+    /// <c>stopwordPresets</c> dictionary on <see cref="TokenizeClient.Text"/>.
     /// </summary>
     public string? StopwordPreset { get; init; }
 }
@@ -42,11 +41,6 @@ public sealed record TextAnalyzerConfig
 public sealed record TokenizeResult
 {
     /// <summary>
-    /// The tokenization method that was applied.
-    /// </summary>
-    public PropertyTokenization Tokenization { get; init; }
-
-    /// <summary>
     /// Tokens as they are stored in the inverted index.
     /// </summary>
     public ImmutableList<string> Indexed { get; init; } = [];
@@ -55,16 +49,6 @@ public sealed record TokenizeResult
     /// Tokens as they are used for query matching (after stopword removal, etc.).
     /// </summary>
     public ImmutableList<string> Query { get; init; } = [];
-
-    /// <summary>
-    /// The text-analyzer configuration that was applied, if any.
-    /// </summary>
-    public TextAnalyzerConfig? AnalyzerConfig { get; init; }
-
-    /// <summary>
-    /// The stopword configuration that was applied, if any.
-    /// </summary>
-    public StopwordConfig? StopwordConfig { get; init; }
 }
 
 /// <summary>
@@ -74,11 +58,6 @@ internal static class TokenizeMapping
 {
     internal static Rest.Dto.TokenizeRequestTokenization ToDto(this PropertyTokenization value) =>
         (Rest.Dto.TokenizeRequestTokenization)(int)value;
-
-    internal static PropertyTokenization ToTokenization(string? wireValue) =>
-        string.IsNullOrEmpty(wireValue)
-            ? PropertyTokenization.Word
-            : wireValue.FromEnumMemberString<PropertyTokenization>();
 
     internal static Rest.Dto.TextAnalyzerConfig? ToDto(this TextAnalyzerConfig? config) =>
         config is null
@@ -129,10 +108,7 @@ internal static class TokenizeMapping
     internal static TokenizeResult ToModel(this Rest.Dto.TokenizeResponse dto) =>
         new()
         {
-            Tokenization = ToTokenization(dto.Tokenization),
             Indexed = dto.Indexed?.ToImmutableList() ?? [],
             Query = dto.Query?.ToImmutableList() ?? [],
-            AnalyzerConfig = dto.AnalyzerConfig.ToModel(),
-            StopwordConfig = dto.StopwordConfig.ToModel(),
         };
 }

--- a/src/Weaviate.Client/PublicAPI.Unshipped.txt
+++ b/src/Weaviate.Client/PublicAPI.Unshipped.txt
@@ -6982,3 +6982,53 @@ virtual Weaviate.Client.Models.ExportBackend.Equals(Weaviate.Client.Models.Expor
 virtual Weaviate.Client.Models.StorageBackend.EqualityContract.get -> System.Type!
 virtual Weaviate.Client.Models.StorageBackend.Equals(Weaviate.Client.Models.StorageBackend? other) -> bool
 virtual Weaviate.Client.Models.StorageBackend.PrintMembers(System.Text.StringBuilder! builder) -> bool
+Weaviate.Client.TokenizeClient
+Weaviate.Client.TokenizeClient.Text(string! text, Weaviate.Client.Models.PropertyTokenization tokenization, Weaviate.Client.Models.TokenizeAnalyzerConfig? analyzerConfig = null, System.Collections.Generic.IDictionary<string!, Weaviate.Client.Models.StopwordConfig!>? stopwordPresets = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.Models.TokenizeResult!>!
+Weaviate.Client.WeaviateClient.Tokenize.get -> Weaviate.Client.TokenizeClient!
+Weaviate.Client.CollectionTokenizeClient
+Weaviate.Client.CollectionTokenizeClient.Property(string! propertyName, string! text, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.Models.TokenizeResult!>!
+Weaviate.Client.CollectionClient.Tokenize.get -> Weaviate.Client.CollectionTokenizeClient!
+Weaviate.Client.Models.AsciiFoldConfig
+Weaviate.Client.Models.AsciiFoldConfig.AsciiFoldConfig(System.Collections.Generic.IReadOnlyList<string!>? Ignore = null) -> void
+Weaviate.Client.Models.AsciiFoldConfig.Ignore.get -> System.Collections.Generic.IReadOnlyList<string!>?
+Weaviate.Client.Models.AsciiFoldConfig.Ignore.init -> void
+Weaviate.Client.Models.AsciiFoldConfig.Equals(Weaviate.Client.Models.AsciiFoldConfig? other) -> bool
+Weaviate.Client.Models.AsciiFoldConfig.<Clone>$() -> Weaviate.Client.Models.AsciiFoldConfig!
+Weaviate.Client.Models.AsciiFoldConfig.Deconstruct(out System.Collections.Generic.IReadOnlyList<string!>? Ignore) -> void
+override Weaviate.Client.Models.AsciiFoldConfig.Equals(object? obj) -> bool
+override Weaviate.Client.Models.AsciiFoldConfig.GetHashCode() -> int
+override Weaviate.Client.Models.AsciiFoldConfig.ToString() -> string!
+static Weaviate.Client.Models.AsciiFoldConfig.operator !=(Weaviate.Client.Models.AsciiFoldConfig? left, Weaviate.Client.Models.AsciiFoldConfig? right) -> bool
+static Weaviate.Client.Models.AsciiFoldConfig.operator ==(Weaviate.Client.Models.AsciiFoldConfig? left, Weaviate.Client.Models.AsciiFoldConfig? right) -> bool
+Weaviate.Client.Models.TokenizeAnalyzerConfig
+Weaviate.Client.Models.TokenizeAnalyzerConfig.TokenizeAnalyzerConfig() -> void
+Weaviate.Client.Models.TokenizeAnalyzerConfig.AsciiFold.get -> Weaviate.Client.Models.AsciiFoldConfig?
+Weaviate.Client.Models.TokenizeAnalyzerConfig.AsciiFold.init -> void
+Weaviate.Client.Models.TokenizeAnalyzerConfig.StopwordPreset.get -> string?
+Weaviate.Client.Models.TokenizeAnalyzerConfig.StopwordPreset.init -> void
+Weaviate.Client.Models.TokenizeAnalyzerConfig.Equals(Weaviate.Client.Models.TokenizeAnalyzerConfig? other) -> bool
+Weaviate.Client.Models.TokenizeAnalyzerConfig.<Clone>$() -> Weaviate.Client.Models.TokenizeAnalyzerConfig!
+override Weaviate.Client.Models.TokenizeAnalyzerConfig.Equals(object? obj) -> bool
+override Weaviate.Client.Models.TokenizeAnalyzerConfig.GetHashCode() -> int
+override Weaviate.Client.Models.TokenizeAnalyzerConfig.ToString() -> string!
+static Weaviate.Client.Models.TokenizeAnalyzerConfig.operator !=(Weaviate.Client.Models.TokenizeAnalyzerConfig? left, Weaviate.Client.Models.TokenizeAnalyzerConfig? right) -> bool
+static Weaviate.Client.Models.TokenizeAnalyzerConfig.operator ==(Weaviate.Client.Models.TokenizeAnalyzerConfig? left, Weaviate.Client.Models.TokenizeAnalyzerConfig? right) -> bool
+Weaviate.Client.Models.TokenizeResult
+Weaviate.Client.Models.TokenizeResult.TokenizeResult() -> void
+Weaviate.Client.Models.TokenizeResult.Tokenization.get -> Weaviate.Client.Models.PropertyTokenization
+Weaviate.Client.Models.TokenizeResult.Tokenization.init -> void
+Weaviate.Client.Models.TokenizeResult.Indexed.get -> System.Collections.Immutable.ImmutableList<string!>!
+Weaviate.Client.Models.TokenizeResult.Indexed.init -> void
+Weaviate.Client.Models.TokenizeResult.Query.get -> System.Collections.Immutable.ImmutableList<string!>!
+Weaviate.Client.Models.TokenizeResult.Query.init -> void
+Weaviate.Client.Models.TokenizeResult.AnalyzerConfig.get -> Weaviate.Client.Models.TokenizeAnalyzerConfig?
+Weaviate.Client.Models.TokenizeResult.AnalyzerConfig.init -> void
+Weaviate.Client.Models.TokenizeResult.StopwordConfig.get -> Weaviate.Client.Models.StopwordConfig?
+Weaviate.Client.Models.TokenizeResult.StopwordConfig.init -> void
+Weaviate.Client.Models.TokenizeResult.Equals(Weaviate.Client.Models.TokenizeResult? other) -> bool
+Weaviate.Client.Models.TokenizeResult.<Clone>$() -> Weaviate.Client.Models.TokenizeResult!
+override Weaviate.Client.Models.TokenizeResult.Equals(object? obj) -> bool
+override Weaviate.Client.Models.TokenizeResult.GetHashCode() -> int
+override Weaviate.Client.Models.TokenizeResult.ToString() -> string!
+static Weaviate.Client.Models.TokenizeResult.operator !=(Weaviate.Client.Models.TokenizeResult? left, Weaviate.Client.Models.TokenizeResult? right) -> bool
+static Weaviate.Client.Models.TokenizeResult.operator ==(Weaviate.Client.Models.TokenizeResult? left, Weaviate.Client.Models.TokenizeResult? right) -> bool

--- a/src/Weaviate.Client/PublicAPI.Unshipped.txt
+++ b/src/Weaviate.Client/PublicAPI.Unshipped.txt
@@ -6983,7 +6983,7 @@ virtual Weaviate.Client.Models.StorageBackend.EqualityContract.get -> System.Typ
 virtual Weaviate.Client.Models.StorageBackend.Equals(Weaviate.Client.Models.StorageBackend? other) -> bool
 virtual Weaviate.Client.Models.StorageBackend.PrintMembers(System.Text.StringBuilder! builder) -> bool
 Weaviate.Client.TokenizeClient
-Weaviate.Client.TokenizeClient.Text(string! text, Weaviate.Client.Models.PropertyTokenization tokenization, Weaviate.Client.Models.TokenizeAnalyzerConfig? analyzerConfig = null, System.Collections.Generic.IDictionary<string!, Weaviate.Client.Models.StopwordConfig!>? stopwordPresets = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.Models.TokenizeResult!>!
+Weaviate.Client.TokenizeClient.Text(string! text, Weaviate.Client.Models.PropertyTokenization tokenization, Weaviate.Client.Models.TextAnalyzerConfig? analyzerConfig = null, System.Collections.Generic.IDictionary<string!, Weaviate.Client.Models.StopwordConfig!>? stopwordPresets = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.Models.TokenizeResult!>!
 Weaviate.Client.WeaviateClient.Tokenize.get -> Weaviate.Client.TokenizeClient!
 Weaviate.Client.CollectionTokenizeClient
 Weaviate.Client.CollectionTokenizeClient.Property(string! propertyName, string! text, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.Models.TokenizeResult!>!
@@ -7000,19 +7000,19 @@ override Weaviate.Client.Models.AsciiFoldConfig.GetHashCode() -> int
 override Weaviate.Client.Models.AsciiFoldConfig.ToString() -> string!
 static Weaviate.Client.Models.AsciiFoldConfig.operator !=(Weaviate.Client.Models.AsciiFoldConfig? left, Weaviate.Client.Models.AsciiFoldConfig? right) -> bool
 static Weaviate.Client.Models.AsciiFoldConfig.operator ==(Weaviate.Client.Models.AsciiFoldConfig? left, Weaviate.Client.Models.AsciiFoldConfig? right) -> bool
-Weaviate.Client.Models.TokenizeAnalyzerConfig
-Weaviate.Client.Models.TokenizeAnalyzerConfig.TokenizeAnalyzerConfig() -> void
-Weaviate.Client.Models.TokenizeAnalyzerConfig.AsciiFold.get -> Weaviate.Client.Models.AsciiFoldConfig?
-Weaviate.Client.Models.TokenizeAnalyzerConfig.AsciiFold.init -> void
-Weaviate.Client.Models.TokenizeAnalyzerConfig.StopwordPreset.get -> string?
-Weaviate.Client.Models.TokenizeAnalyzerConfig.StopwordPreset.init -> void
-Weaviate.Client.Models.TokenizeAnalyzerConfig.Equals(Weaviate.Client.Models.TokenizeAnalyzerConfig? other) -> bool
-Weaviate.Client.Models.TokenizeAnalyzerConfig.<Clone>$() -> Weaviate.Client.Models.TokenizeAnalyzerConfig!
-override Weaviate.Client.Models.TokenizeAnalyzerConfig.Equals(object? obj) -> bool
-override Weaviate.Client.Models.TokenizeAnalyzerConfig.GetHashCode() -> int
-override Weaviate.Client.Models.TokenizeAnalyzerConfig.ToString() -> string!
-static Weaviate.Client.Models.TokenizeAnalyzerConfig.operator !=(Weaviate.Client.Models.TokenizeAnalyzerConfig? left, Weaviate.Client.Models.TokenizeAnalyzerConfig? right) -> bool
-static Weaviate.Client.Models.TokenizeAnalyzerConfig.operator ==(Weaviate.Client.Models.TokenizeAnalyzerConfig? left, Weaviate.Client.Models.TokenizeAnalyzerConfig? right) -> bool
+Weaviate.Client.Models.TextAnalyzerConfig
+Weaviate.Client.Models.TextAnalyzerConfig.TextAnalyzerConfig() -> void
+Weaviate.Client.Models.TextAnalyzerConfig.AsciiFold.get -> Weaviate.Client.Models.AsciiFoldConfig?
+Weaviate.Client.Models.TextAnalyzerConfig.AsciiFold.init -> void
+Weaviate.Client.Models.TextAnalyzerConfig.StopwordPreset.get -> string?
+Weaviate.Client.Models.TextAnalyzerConfig.StopwordPreset.init -> void
+Weaviate.Client.Models.TextAnalyzerConfig.Equals(Weaviate.Client.Models.TextAnalyzerConfig? other) -> bool
+Weaviate.Client.Models.TextAnalyzerConfig.<Clone>$() -> Weaviate.Client.Models.TextAnalyzerConfig!
+override Weaviate.Client.Models.TextAnalyzerConfig.Equals(object? obj) -> bool
+override Weaviate.Client.Models.TextAnalyzerConfig.GetHashCode() -> int
+override Weaviate.Client.Models.TextAnalyzerConfig.ToString() -> string!
+static Weaviate.Client.Models.TextAnalyzerConfig.operator !=(Weaviate.Client.Models.TextAnalyzerConfig? left, Weaviate.Client.Models.TextAnalyzerConfig? right) -> bool
+static Weaviate.Client.Models.TextAnalyzerConfig.operator ==(Weaviate.Client.Models.TextAnalyzerConfig? left, Weaviate.Client.Models.TextAnalyzerConfig? right) -> bool
 Weaviate.Client.Models.TokenizeResult
 Weaviate.Client.Models.TokenizeResult.TokenizeResult() -> void
 Weaviate.Client.Models.TokenizeResult.Tokenization.get -> Weaviate.Client.Models.PropertyTokenization
@@ -7021,7 +7021,7 @@ Weaviate.Client.Models.TokenizeResult.Indexed.get -> System.Collections.Immutabl
 Weaviate.Client.Models.TokenizeResult.Indexed.init -> void
 Weaviate.Client.Models.TokenizeResult.Query.get -> System.Collections.Immutable.ImmutableList<string!>!
 Weaviate.Client.Models.TokenizeResult.Query.init -> void
-Weaviate.Client.Models.TokenizeResult.AnalyzerConfig.get -> Weaviate.Client.Models.TokenizeAnalyzerConfig?
+Weaviate.Client.Models.TokenizeResult.AnalyzerConfig.get -> Weaviate.Client.Models.TextAnalyzerConfig?
 Weaviate.Client.Models.TokenizeResult.AnalyzerConfig.init -> void
 Weaviate.Client.Models.TokenizeResult.StopwordConfig.get -> Weaviate.Client.Models.StopwordConfig?
 Weaviate.Client.Models.TokenizeResult.StopwordConfig.init -> void
@@ -7032,3 +7032,9 @@ override Weaviate.Client.Models.TokenizeResult.GetHashCode() -> int
 override Weaviate.Client.Models.TokenizeResult.ToString() -> string!
 static Weaviate.Client.Models.TokenizeResult.operator !=(Weaviate.Client.Models.TokenizeResult? left, Weaviate.Client.Models.TokenizeResult? right) -> bool
 static Weaviate.Client.Models.TokenizeResult.operator ==(Weaviate.Client.Models.TokenizeResult? left, Weaviate.Client.Models.TokenizeResult? right) -> bool
+Weaviate.Client.Models.Property.TextAnalyzer.get -> Weaviate.Client.Models.TextAnalyzerConfig?
+Weaviate.Client.Models.Property.TextAnalyzer.init -> void
+Weaviate.Client.Models.InvertedIndexConfig.StopwordPresets.get -> System.Collections.Generic.IDictionary<string!, System.Collections.Generic.IList<string!>!>?
+Weaviate.Client.Models.InvertedIndexConfig.StopwordPresets.set -> void
+Weaviate.Client.Models.InvertedIndexConfigUpdate.StopwordPresets.get -> System.Collections.Generic.IDictionary<string!, System.Collections.Generic.IList<string!>!>?
+Weaviate.Client.Models.InvertedIndexConfigUpdate.StopwordPresets.set -> void

--- a/src/Weaviate.Client/PublicAPI.Unshipped.txt
+++ b/src/Weaviate.Client/PublicAPI.Unshipped.txt
@@ -6983,7 +6983,7 @@ virtual Weaviate.Client.Models.StorageBackend.EqualityContract.get -> System.Typ
 virtual Weaviate.Client.Models.StorageBackend.Equals(Weaviate.Client.Models.StorageBackend? other) -> bool
 virtual Weaviate.Client.Models.StorageBackend.PrintMembers(System.Text.StringBuilder! builder) -> bool
 Weaviate.Client.TokenizeClient
-Weaviate.Client.TokenizeClient.Text(string! text, Weaviate.Client.Models.PropertyTokenization tokenization, Weaviate.Client.Models.TextAnalyzerConfig? analyzerConfig = null, System.Collections.Generic.IDictionary<string!, Weaviate.Client.Models.StopwordConfig!>? stopwordPresets = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.Models.TokenizeResult!>!
+Weaviate.Client.TokenizeClient.Text(string! text, Weaviate.Client.Models.PropertyTokenization tokenization, Weaviate.Client.Models.TextAnalyzerConfig? analyzerConfig = null, Weaviate.Client.Models.StopwordConfig? stopwords = null, System.Collections.Generic.IDictionary<string!, System.Collections.Generic.IList<string!>!>? stopwordPresets = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.Models.TokenizeResult!>!
 Weaviate.Client.WeaviateClient.Tokenize.get -> Weaviate.Client.TokenizeClient!
 Weaviate.Client.CollectionTokenizeClient
 Weaviate.Client.CollectionTokenizeClient.Property(string! propertyName, string! text, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Weaviate.Client.Models.TokenizeResult!>!
@@ -7015,16 +7015,10 @@ static Weaviate.Client.Models.TextAnalyzerConfig.operator !=(Weaviate.Client.Mod
 static Weaviate.Client.Models.TextAnalyzerConfig.operator ==(Weaviate.Client.Models.TextAnalyzerConfig? left, Weaviate.Client.Models.TextAnalyzerConfig? right) -> bool
 Weaviate.Client.Models.TokenizeResult
 Weaviate.Client.Models.TokenizeResult.TokenizeResult() -> void
-Weaviate.Client.Models.TokenizeResult.Tokenization.get -> Weaviate.Client.Models.PropertyTokenization
-Weaviate.Client.Models.TokenizeResult.Tokenization.init -> void
 Weaviate.Client.Models.TokenizeResult.Indexed.get -> System.Collections.Immutable.ImmutableList<string!>!
 Weaviate.Client.Models.TokenizeResult.Indexed.init -> void
 Weaviate.Client.Models.TokenizeResult.Query.get -> System.Collections.Immutable.ImmutableList<string!>!
 Weaviate.Client.Models.TokenizeResult.Query.init -> void
-Weaviate.Client.Models.TokenizeResult.AnalyzerConfig.get -> Weaviate.Client.Models.TextAnalyzerConfig?
-Weaviate.Client.Models.TokenizeResult.AnalyzerConfig.init -> void
-Weaviate.Client.Models.TokenizeResult.StopwordConfig.get -> Weaviate.Client.Models.StopwordConfig?
-Weaviate.Client.Models.TokenizeResult.StopwordConfig.init -> void
 Weaviate.Client.Models.TokenizeResult.Equals(Weaviate.Client.Models.TokenizeResult? other) -> bool
 Weaviate.Client.Models.TokenizeResult.<Clone>$() -> Weaviate.Client.Models.TokenizeResult!
 override Weaviate.Client.Models.TokenizeResult.Equals(object? obj) -> bool

--- a/src/Weaviate.Client/Rest/Dto/Extensions.cs
+++ b/src/Weaviate.Client/Rest/Dto/Extensions.cs
@@ -88,6 +88,7 @@ internal partial record NestedProperty
             IndexRangeFilters = IndexRangeFilters,
             PropertyTokenization = (Models.PropertyTokenization?)Tokenization,
             NestedProperties = NestedProperties?.Select(np => np.ToModel()).ToArray(),
+            TextAnalyzer = Weaviate.Client.Models.TokenizeMapping.ToModel(TextAnalyzer),
         };
     }
 }
@@ -150,6 +151,7 @@ internal partial record Property
             NestedProperties = NestedProperties?.Select(np => np.ToModel()).ToArray(),
             SkipVectorization = skipVectorization,
             VectorizePropertyName = vectorizePropertyName,
+            TextAnalyzer = Weaviate.Client.Models.TokenizeMapping.ToModel(TextAnalyzer),
         };
     }
 

--- a/src/Weaviate.Client/Rest/Dto/Models.g.cs
+++ b/src/Weaviate.Client/Rest/Dto/Models.g.cs
@@ -887,7 +887,7 @@ namespace Weaviate.Client.Rest.Dto
         public System.Collections.Generic.IList<TokenizerUserDictConfig>? TokenizerUserDict { get; set; } = default!;
 
         /// <summary>
-        /// User-defined named stopword lists. Each key is a preset name that can be referenced by a property's textAnalyzer.stopwordPreset field. The value is an array of stopword strings.
+        /// User-defined named stopword lists. Each key is a preset name that can be referenced by a property's textAnalyzer.stopwordPreset field. The value is an array of stopword strings. Preset names must not be empty or whitespace-only; each list must contain at least one word; individual words must not be empty or whitespace-only.
         /// </summary>
 
         [System.Text.Json.Serialization.JsonPropertyName("stopwordPresets")]
@@ -1047,45 +1047,29 @@ namespace Weaviate.Client.Rest.Dto
         public TextAnalyzerConfig? AnalyzerConfig { get; set; } = default!;
 
         /// <summary>
-        /// Optional named stopword configurations. Each key is a preset name that can be referenced by analyzerConfig.stopwordPreset. Each value is a StopwordConfig (with optional preset, additions, and removals).
+        /// Optional fallback stopword configuration. Used when analyzerConfig.stopwordPreset is not set. Shape matches InvertedIndexConfig.stopwords on a collection. When analyzerConfig.stopwordPreset is not set and this field is omitted, word tokenization defaults to preset 'en'. Mutually exclusive with stopwordPresets — pass one or the other, not both.
+        /// </summary>
+
+        [System.Text.Json.Serialization.JsonPropertyName("stopwords")]
+
+        public StopwordConfig? Stopwords { get; set; } = default!;
+
+        /// <summary>
+        /// Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in. Preset names must not be empty or whitespace-only; each word list must contain at least one word; individual words must not be empty or whitespace-only. Mutually exclusive with stopwords — pass one or the other, not both.
         /// </summary>
 
         [System.Text.Json.Serialization.JsonPropertyName("stopwordPresets")]
 
-        public System.Collections.Generic.IDictionary<string, StopwordConfig>? StopwordPresets { get; set; } = default!;
+        public System.Collections.Generic.IDictionary<string, System.Collections.Generic.IList<string>>? StopwordPresets { get; set; } = default!;
 
     }
 
     /// <summary>
-    /// Response from the tokenize endpoint.
+    /// Response from the tokenize endpoints. Returns `indexed` text and text used at `query` time
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.1.0 (NJsonSchema v11.5.1.0 (Newtonsoft.Json v13.0.0.0))")]
     internal partial record TokenizeResponse
     {
-        /// <summary>
-        /// The tokenization method that was applied.
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("tokenization")]
-
-        public string? Tokenization { get; set; } = default!;
-
-        /// <summary>
-        /// The text analyzer configuration that was used, if any.
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("analyzerConfig")]
-
-        public TextAnalyzerConfig? AnalyzerConfig { get; set; } = default!;
-
-        /// <summary>
-        /// The stopword configuration that was used, if any.
-        /// </summary>
-
-        [System.Text.Json.Serialization.JsonPropertyName("stopwordConfig")]
-
-        public StopwordConfig? StopwordConfig { get; set; } = default!;
-
         /// <summary>
         /// The tokens as they would be stored in the inverted index.
         /// </summary>

--- a/src/Weaviate.Client/Rest/Endpoints.cs
+++ b/src/Weaviate.Client/Rest/Endpoints.cs
@@ -208,6 +208,21 @@ internal static partial class WeaviateEndpoints
         return path;
     }
 
+    /// <summary>
+    /// Path for the generic tokenize endpoint.
+    /// </summary>
+    /// <returns>The string</returns>
+    internal static string Tokenize() => "tokenize";
+
+    /// <summary>
+    /// Path for the per-property tokenize endpoint.
+    /// </summary>
+    /// <param name="className">The collection (class) name.</param>
+    /// <param name="propertyName">The property name.</param>
+    /// <returns>The string</returns>
+    internal static string TokenizeProperty(string className, string propertyName) =>
+        $"schema/{className}/properties/{propertyName}/tokenize";
+
     // Well-known endpoints
     /// <summary>
     /// Wells the known live

--- a/src/Weaviate.Client/Rest/Schema/openapi.json
+++ b/src/Weaviate.Client/Rest/Schema/openapi.json
@@ -583,7 +583,10 @@
     "ExportCreateRequest": {
       "description": "Request to create a new export operation",
       "type": "object",
-      "required": ["id", "file_format"],
+      "required": [
+        "id",
+        "file_format"
+      ],
       "properties": {
         "id": {
           "type": "string",
@@ -592,7 +595,9 @@
         "file_format": {
           "type": "string",
           "description": "Output file format for the export.",
-          "enum": ["parquet"]
+          "enum": [
+            "parquet"
+          ]
         },
         "include": {
           "type": "array",
@@ -629,7 +634,9 @@
         "status": {
           "type": "string",
           "description": "Current status of the export",
-          "enum": ["STARTED"]
+          "enum": [
+            "STARTED"
+          ]
         },
         "startedAt": {
           "type": "string",
@@ -664,7 +671,13 @@
         "status": {
           "type": "string",
           "description": "Current status of the export",
-          "enum": ["STARTED", "TRANSFERRING", "SUCCESS", "FAILED", "CANCELED"]
+          "enum": [
+            "STARTED",
+            "TRANSFERRING",
+            "SUCCESS",
+            "FAILED",
+            "CANCELED"
+          ]
         },
         "startedAt": {
           "type": "string",
@@ -711,7 +724,12 @@
         "status": {
           "type": "string",
           "description": "Status of this shard's export",
-          "enum": ["TRANSFERRING", "SUCCESS", "FAILED", "SKIPPED"]
+          "enum": [
+            "TRANSFERRING",
+            "SUCCESS",
+            "FAILED",
+            "SKIPPED"
+          ]
         },
         "objectsExported": {
           "type": "integer",
@@ -849,7 +867,7 @@
           }
         },
         "stopwordPresets": {
-          "description": "User-defined named stopword lists. Each key is a preset name that can be referenced by a property's textAnalyzer.stopwordPreset field. The value is an array of stopword strings.",
+          "description": "User-defined named stopword lists. Each key is a preset name that can be referenced by a property's textAnalyzer.stopwordPreset field. The value is an array of stopword strings. Preset names must not be empty or whitespace-only; each list must contain at least one word; individual words must not be empty or whitespace-only.",
           "type": "object",
           "x-omitempty": true,
           "additionalProperties": {
@@ -965,7 +983,10 @@
     "TokenizeRequest": {
       "description": "Request body for the generic tokenize endpoint.",
       "type": "object",
-      "required": ["text", "tokenization"],
+      "required": [
+        "text",
+        "tokenization"
+      ],
       "properties": {
         "text": {
           "description": "The text to tokenize.",
@@ -990,32 +1011,27 @@
           "description": "Optional text analyzer configuration (e.g. ASCII folding).",
           "$ref": "#/definitions/TextAnalyzerConfig"
         },
+        "stopwords": {
+          "description": "Optional fallback stopword configuration. Used when analyzerConfig.stopwordPreset is not set. Shape matches InvertedIndexConfig.stopwords on a collection. When analyzerConfig.stopwordPreset is not set and this field is omitted, word tokenization defaults to preset 'en'. Mutually exclusive with stopwordPresets — pass one or the other, not both.",
+          "$ref": "#/definitions/StopwordConfig"
+        },
         "stopwordPresets": {
-          "description": "Optional named stopword configurations. Each key is a preset name that can be referenced by analyzerConfig.stopwordPreset. Each value is a StopwordConfig (with optional preset, additions, and removals).",
+          "description": "Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in. Preset names must not be empty or whitespace-only; each word list must contain at least one word; individual words must not be empty or whitespace-only. Mutually exclusive with stopwords — pass one or the other, not both.",
           "type": "object",
           "x-omitempty": true,
           "additionalProperties": {
-            "$ref": "#/definitions/StopwordConfig"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       }
     },
     "TokenizeResponse": {
-      "description": "Response from the tokenize endpoint.",
+      "description": "Response from the tokenize endpoints. Returns `indexed` text and text used at `query` time",
       "type": "object",
       "properties": {
-        "tokenization": {
-          "description": "The tokenization method that was applied.",
-          "type": "string"
-        },
-        "analyzerConfig": {
-          "description": "The text analyzer configuration that was used, if any.",
-          "$ref": "#/definitions/TextAnalyzerConfig"
-        },
-        "stopwordConfig": {
-          "description": "The stopword configuration that was used, if any.",
-          "$ref": "#/definitions/StopwordConfig"
-        },
         "indexed": {
           "description": "The tokens as they would be stored in the inverted index.",
           "type": "array",
@@ -1035,7 +1051,9 @@
     "PropertyTokenizeRequest": {
       "description": "Request body for the property-specific tokenize endpoint.",
       "type": "object",
-      "required": ["text"],
+      "required": [
+        "text"
+      ],
       "properties": {
         "text": {
           "description": "The text to tokenize using the property's configured tokenization.",
@@ -3480,7 +3498,7 @@
     },
     "description": "# Introduction<br/> Weaviate is an open source, AI-native vector database that helps developers create intuitive and reliable AI-powered applications. <br/> ### Base Path <br/>The base path for the Weaviate server is structured as `[YOUR-WEAVIATE-HOST]:[PORT]/v1`. As an example, if you wish to access the `schema` endpoint on a local instance, you would navigate to `http://localhost:8080/v1/schema`. Ensure you replace `[YOUR-WEAVIATE-HOST]` and `[PORT]` with your actual server host and port number respectively. <br/> ### Questions? <br/>If you have any comments or questions, please feel free to reach out to us at the community forum [https://forum.weaviate.io/](https://forum.weaviate.io/). <br/>### Issues? <br/>If you find a bug or want to file a feature request, please open an issue on our GitHub repository for [Weaviate](https://github.com/weaviate/weaviate). <br/>### Need more documentation? <br/>For a quickstart, code examples, concepts and more, please visit our [documentation page](https://docs.weaviate.io/weaviate).",
     "title": "Weaviate REST API",
-    "version": "1.37.1"
+    "version": "1.37.2"
   },
   "parameters": {
     "CommonAfterParameterQuery": {
@@ -10004,29 +10022,48 @@
     "/mcp": {
       "post": {
         "description": "MCP Streamable HTTP endpoint. Handles JSON-RPC requests for tool discovery and invocation.",
-        "tags": ["mcp"],
+        "tags": [
+          "mcp"
+        ],
         "operationId": "mcp.post",
-        "consumes": ["application/json"],
-        "produces": ["application/json", "text/event-stream"],
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json",
+          "text/event-stream"
+        ],
         "responses": {
-          "200": { "description": "JSON-RPC response or SSE stream" }
+          "200": {
+            "description": "JSON-RPC response or SSE stream"
+          }
         }
       },
       "get": {
         "description": "Opens an SSE stream for receiving MCP server-sent events.",
-        "tags": ["mcp"],
+        "tags": [
+          "mcp"
+        ],
         "operationId": "mcp.get",
-        "produces": ["text/event-stream"],
+        "produces": [
+          "text/event-stream"
+        ],
         "responses": {
-          "200": { "description": "SSE event stream" }
+          "200": {
+            "description": "SSE event stream"
+          }
         }
       },
       "delete": {
         "description": "Terminates an MCP session.",
-        "tags": ["mcp"],
+        "tags": [
+          "mcp"
+        ],
         "operationId": "mcp.delete",
         "responses": {
-          "200": { "description": "Session terminated" }
+          "200": {
+            "description": "Session terminated"
+          }
         }
       }
     }

--- a/src/Weaviate.Client/Rest/Tokenize.cs
+++ b/src/Weaviate.Client/Rest/Tokenize.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using System.Net.Http.Json;
+using Weaviate.Client.Rest.Dto;
+
+namespace Weaviate.Client.Rest;
+
+internal partial class WeaviateRestClient
+{
+    /// <summary>
+    /// Calls <c>POST /v1/tokenize</c>.
+    /// </summary>
+    internal async Task<TokenizeResponse?> Tokenize(
+        TokenizeRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var response = await _httpClient.PostAsJsonAsync(
+            WeaviateEndpoints.Tokenize(),
+            request,
+            options: RestJsonSerializerOptions,
+            cancellationToken: cancellationToken
+        );
+
+        await response.ManageStatusCode([HttpStatusCode.OK], "tokenize");
+
+        return await response.DecodeAsync<TokenizeResponse>(cancellationToken);
+    }
+
+    /// <summary>
+    /// Calls <c>POST /v1/schema/{className}/properties/{propertyName}/tokenize</c>.
+    /// </summary>
+    internal async Task<TokenizeResponse?> TokenizeProperty(
+        string className,
+        string propertyName,
+        PropertyTokenizeRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var response = await _httpClient.PostAsJsonAsync(
+            WeaviateEndpoints.TokenizeProperty(className, propertyName),
+            request,
+            options: RestJsonSerializerOptions,
+            cancellationToken: cancellationToken
+        );
+
+        await response.ManageStatusCode(
+            [HttpStatusCode.OK],
+            "tokenize property",
+            ResourceType.Property
+        );
+
+        return await response.DecodeAsync<TokenizeResponse>(cancellationToken);
+    }
+}

--- a/src/Weaviate.Client/TokenizeClient.cs
+++ b/src/Weaviate.Client/TokenizeClient.cs
@@ -18,17 +18,26 @@ public sealed class TokenizeClient
 
     /// <summary>
     /// Tokenizes <paramref name="text"/> using the given <paramref name="tokenization"/> strategy.
-    /// Returns the indexed and query forms produced by the server, plus the analyzer/stopword
-    /// configurations that were applied.
+    /// Returns the indexed and query token forms produced by the server.
     /// </summary>
     /// <param name="text">The text to tokenize.</param>
     /// <param name="tokenization">The tokenization method to apply.</param>
-    /// <param name="analyzerConfig">Optional text analyzer configuration (e.g. ASCII folding, stopword preset).</param>
+    /// <param name="analyzerConfig">Optional text analyzer configuration (e.g. ASCII folding, stopword preset name).</param>
+    /// <param name="stopwords">
+    /// Optional one-off stopword block applied to this request. Mirrors the collection-level
+    /// <c>invertedIndexConfig.stopwords</c> shape (preset + additions + removals).
+    /// Mutually exclusive with <paramref name="stopwordPresets"/>.
+    /// </param>
     /// <param name="stopwordPresets">
-    /// Optional named stopword configurations. Each key is a preset name that can be referenced by
-    /// <see cref="TextAnalyzerConfig.StopwordPreset"/>. Each value is a <see cref="StopwordConfig"/>.
+    /// Optional named stopword catalog. Each key is a preset name that can be referenced by
+    /// <see cref="TextAnalyzerConfig.StopwordPreset"/>; each value is a plain list of stopword strings.
+    /// Matches the collection-level <c>invertedIndexConfig.stopwordPresets</c> shape.
+    /// Mutually exclusive with <paramref name="stopwords"/>.
     /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when both <paramref name="stopwords"/> and <paramref name="stopwordPresets"/> are supplied.
+    /// </exception>
     /// <exception cref="WeaviateVersionMismatchException">
     /// Thrown when the connected server version is below 1.37.0.
     /// </exception>
@@ -37,11 +46,17 @@ public sealed class TokenizeClient
         string text,
         PropertyTokenization tokenization,
         TextAnalyzerConfig? analyzerConfig = null,
-        IDictionary<string, StopwordConfig>? stopwordPresets = null,
+        StopwordConfig? stopwords = null,
+        IDictionary<string, IList<string>>? stopwordPresets = null,
         CancellationToken cancellationToken = default
     )
     {
         ArgumentNullException.ThrowIfNull(text);
+        if (stopwords is not null && stopwordPresets is not null)
+            throw new ArgumentException(
+                "stopwords and stopwordPresets are mutually exclusive; pass only one.",
+                nameof(stopwords)
+            );
 
         await _client.EnsureVersion<TokenizeClient>();
 
@@ -50,10 +65,8 @@ public sealed class TokenizeClient
             Text = text,
             Tokenization = tokenization.ToDto(),
             AnalyzerConfig = analyzerConfig.ToDto(),
-            StopwordPresets = stopwordPresets?.ToDictionary(
-                kvp => kvp.Key,
-                kvp => kvp.Value.ToDto()
-            ),
+            Stopwords = stopwords?.ToDto(),
+            StopwordPresets = stopwordPresets,
         };
 
         var response =

--- a/src/Weaviate.Client/TokenizeClient.cs
+++ b/src/Weaviate.Client/TokenizeClient.cs
@@ -1,0 +1,67 @@
+using Weaviate.Client.Models;
+
+namespace Weaviate.Client;
+
+/// <summary>
+/// Exposes the <c>/v1/tokenize</c> endpoint for inspecting how text is tokenized
+/// with a given tokenization method and analyzer configuration.
+/// Requires Weaviate server version 1.37.0 or later.
+/// </summary>
+public sealed class TokenizeClient
+{
+    private readonly WeaviateClient _client;
+
+    internal TokenizeClient(WeaviateClient client)
+    {
+        _client = client;
+    }
+
+    /// <summary>
+    /// Tokenizes <paramref name="text"/> using the given <paramref name="tokenization"/> strategy.
+    /// Returns the indexed and query forms produced by the server, plus the analyzer/stopword
+    /// configurations that were applied.
+    /// </summary>
+    /// <param name="text">The text to tokenize.</param>
+    /// <param name="tokenization">The tokenization method to apply.</param>
+    /// <param name="analyzerConfig">Optional text analyzer configuration (e.g. ASCII folding, stopword preset).</param>
+    /// <param name="stopwordPresets">
+    /// Optional named stopword configurations. Each key is a preset name that can be referenced by
+    /// <see cref="TokenizeAnalyzerConfig.StopwordPreset"/>. Each value is a <see cref="StopwordConfig"/>.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="WeaviateVersionMismatchException">
+    /// Thrown when the connected server version is below 1.37.0.
+    /// </exception>
+    [RequiresWeaviateVersion(1, 37, 0)]
+    public async Task<TokenizeResult> Text(
+        string text,
+        PropertyTokenization tokenization,
+        TokenizeAnalyzerConfig? analyzerConfig = null,
+        IDictionary<string, StopwordConfig>? stopwordPresets = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        await _client.EnsureVersion<TokenizeClient>();
+
+        var request = new Rest.Dto.TokenizeRequest
+        {
+            Text = text,
+            Tokenization = tokenization.ToDto(),
+            AnalyzerConfig = analyzerConfig.ToDto(),
+            StopwordPresets = stopwordPresets?.ToDictionary(
+                kvp => kvp.Key,
+                kvp => kvp.Value.ToDto()
+            ),
+        };
+
+        var response =
+            await _client.RestClient.Tokenize(request, cancellationToken)
+            ?? throw new WeaviateClientException(
+                new InvalidOperationException("Tokenize endpoint returned an empty response.")
+            );
+
+        return response.ToModel();
+    }
+}

--- a/src/Weaviate.Client/TokenizeClient.cs
+++ b/src/Weaviate.Client/TokenizeClient.cs
@@ -26,7 +26,7 @@ public sealed class TokenizeClient
     /// <param name="analyzerConfig">Optional text analyzer configuration (e.g. ASCII folding, stopword preset).</param>
     /// <param name="stopwordPresets">
     /// Optional named stopword configurations. Each key is a preset name that can be referenced by
-    /// <see cref="TokenizeAnalyzerConfig.StopwordPreset"/>. Each value is a <see cref="StopwordConfig"/>.
+    /// <see cref="TextAnalyzerConfig.StopwordPreset"/>. Each value is a <see cref="StopwordConfig"/>.
     /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <exception cref="WeaviateVersionMismatchException">
@@ -36,7 +36,7 @@ public sealed class TokenizeClient
     public async Task<TokenizeResult> Text(
         string text,
         PropertyTokenization tokenization,
-        TokenizeAnalyzerConfig? analyzerConfig = null,
+        TextAnalyzerConfig? analyzerConfig = null,
         IDictionary<string, StopwordConfig>? stopwordPresets = null,
         CancellationToken cancellationToken = default
     )

--- a/src/Weaviate.Client/WeaviateClient.cs
+++ b/src/Weaviate.Client/WeaviateClient.cs
@@ -194,6 +194,12 @@ public partial class WeaviateClient : IDisposable
     public GroupsClient Groups { get; }
 
     /// <summary>
+    /// Gets the tokenize client for inspecting how text is tokenized by the server.
+    /// Requires Weaviate server version 1.37.0 or later.
+    /// </summary>
+    public TokenizeClient Tokenize { get; }
+
+    /// <summary>
     /// Ises the weaviate domain using the specified url
     /// </summary>
     /// <param name="url">The url</param>
@@ -227,6 +233,7 @@ public partial class WeaviateClient : IDisposable
         Users = new UsersClient(this);
         Roles = new RolesClient(this);
         Groups = new GroupsClient(this);
+        Tokenize = new TokenizeClient(this);
     }
 
     /// <summary>
@@ -267,6 +274,7 @@ public partial class WeaviateClient : IDisposable
         Users = new UsersClient(this);
         Roles = new RolesClient(this);
         Groups = new GroupsClient(this);
+        Tokenize = new TokenizeClient(this);
     }
 
     /// <summary>
@@ -322,6 +330,7 @@ public partial class WeaviateClient : IDisposable
         Users = new UsersClient(this);
         Roles = new RolesClient(this);
         Groups = new GroupsClient(this);
+        Tokenize = new TokenizeClient(this);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Ports two related Weaviate 1.37.0 features from the Python client into one stacked PR:

1. **[python-client PR #2012](https://github.com/weaviate/weaviate-python-client/pull/2012) — `/v1/tokenize` endpoints**
   - `client.Tokenize.Text(text, tokenization, analyzerConfig?, stopwordPresets?, ct)` (`POST /v1/tokenize`)
   - `collection.Tokenize.Property(propertyName, text, ct)` (`POST /v1/schema/{class}/properties/{prop}/tokenize`)
   - Public surface mirrors the TS client's `tokenize` namespace design.
   - `AsciiFold` is a nullable record (`AsciiFoldConfig? AsciiFold`) — null = disabled, non-null = enabled with optional `Ignore` list. The invalid "ignore without fold" state is unrepresentable, so no runtime validator is needed.
   - Version-gated at 1.37.0 via `[RequiresWeaviateVersion(1, 37, 0)]` + `EnsureVersion<T>()`.

2. **[python-client PR #2006](https://github.com/weaviate/weaviate-python-client/pull/2006) — property-level `TextAnalyzer` + collection-level `StopwordPresets`**
   - `Property.TextAnalyzer`: pin ASCII folding and stopword preset per property at index time. Reuses the `TextAnalyzerConfig` record from (1) so tokenize-at-query and index-at-insert stay aligned. Propagates through nested properties.
   - `InvertedIndexConfig.StopwordPresets`: named preset → word-list map on the collection inverted-index config. Properties reference presets via `TextAnalyzer.StopwordPreset`.
   - `InvertedIndexConfigUpdate.StopwordPresets`: mirrors the set accessor on the update wrapper so `c.InvertedIndexConfig.StopwordPresets = ...` works inside `collection.Config.Update(...)`.
   - Preflight in `CollectionsClient.Create` detects either feature in the incoming schema and throws `WeaviateVersionMismatchException` when the server is older than 1.37.0, before any REST call.
   - Originally planned as a follow-up PR but folded into this one since both features share the same `TextAnalyzerConfig` shape and version gate. `TokenizeAnalyzerConfig` was renamed to `TextAnalyzerConfig` to match the server type name.

Docs: [TOKENIZE_API_USAGE.md](docs/TOKENIZE_API_USAGE.md) — end-to-end guide covering both scopes, including schema-time analyzer + preset examples.

## Out of scope

- Java parity + Java `gse_ch` fix — separate tracked work.
- gRPC tokenize (no proto as of 1.37.0).

## Test plan

- [x] `dotnet build src/Weaviate.Client/` → 0 errors
- [x] `dotnet build src/Weaviate.Client.Tests/` → 0 warnings, 0 errors
- [x] `dotnet test --filter FullyQualifiedName~TestTokenize` → 16/16 passed against Weaviate 1.37.1
- [ ] `dotnet test --filter FullyQualifiedName~TestCollectionTextAnalyzer` against Weaviate 1.37.1
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)