### PR TITLE
chore: pre-export fixes (split out from #324)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,15 @@ dotnet test src/Weaviate.Client.Tests --filter "FullyQualifiedName~Integration"
 ./ci/stop_weaviate.sh 1.36.9    # stop when done
 ```
 
+## REST DTO Generation
+
+`src/Weaviate.Client/Rest/Dto/Models.g.cs` is **auto-generated** — never edit it manually. To update it:
+
+1. Run `./tools/openapi_sync.sh` followed by the desired branch or tag to target from the github.com/weaviate/weaviate repo
+2. Run `./tools/gen_rest_dto.sh` to regenerate `Models.g.cs` via NSwag
+
+To customize the generated output (e.g., access modifiers), edit the Liquid templates in `src/Weaviate.Client/Rest/Schema/Templates/`. These override NSwag's built-in templates. `File.liquid` overrides the file-level template (controls `FileResponse` visibility, etc.).
+
 ## Public API Tracking
 
 After adding public types/members, run:

--- a/docs/BATCH_API_USAGE.md
+++ b/docs/BATCH_API_USAGE.md
@@ -219,7 +219,6 @@ The `BatchContext.State` property indicates the current state:
 - `Open` - Batch is accepting objects
 - `InFlight` - Processing in progress
 - `Closed` - Batch completed normally
-- `Aborted` - Batch failed with error
 
 ## Reference Batching
 

--- a/src/Weaviate.Client.Tests/Integration/TestReplication.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestReplication.cs
@@ -490,7 +490,8 @@ public class TestReplication : IntegrationTests
         {
             await _weaviate.Cluster.Replications.DeleteAll(TestContext.Current.CancellationToken);
 
-            // Poll up to 30s for asynchronous deletion to take effect.
+            // Poll up to 30s for asynchronous deletion to take effect. Operations flagged
+            // ScheduledForDelete count as deleted — the server clears them on its own cadence.
             for (int i = 0; i < 60; i++)
             {
                 var operations = await _weaviate.Cluster.Replications.ListAll(
@@ -499,7 +500,7 @@ public class TestReplication : IntegrationTests
                 Trace.WriteLine(
                     $"Attempt {attempt + 1}, poll {i}: remaining operations: {operations.Count()}"
                 );
-                if (!operations.Any())
+                if (!operations.Any(o => o.ScheduledForDelete != true))
                 {
                     allDeleted = true;
                     break;

--- a/src/Weaviate.Client.VectorData/PublicAPI.Unshipped.txt
+++ b/src/Weaviate.Client.VectorData/PublicAPI.Unshipped.txt
@@ -3,6 +3,7 @@ Weaviate.Client.VectorData.DependencyInjection.WeaviateVectorDataServiceCollecti
 Weaviate.Client.VectorData.WeaviateVectorStore
 Weaviate.Client.VectorData.WeaviateVectorStore.WeaviateVectorStore(Weaviate.Client.WeaviateClient! client, Weaviate.Client.VectorData.WeaviateVectorStoreOptions? options = null) -> void
 Weaviate.Client.VectorData.WeaviateVectorStoreCollection<TKey, TRecord>
+Weaviate.Client.VectorData.WeaviateVectorStoreCollection<TKey, TRecord>.HybridSearchAsync<TInput>(TInput searchValue, System.Collections.Generic.ICollection<string!>! keywords, int top, Microsoft.Extensions.VectorData.HybridSearchOptions<TRecord!>? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Microsoft.Extensions.VectorData.VectorSearchResult<TRecord!>!>!
 Weaviate.Client.VectorData.WeaviateVectorStoreCollection<TKey, TRecord>.WeaviateVectorStoreCollection(Weaviate.Client.WeaviateClient! client, string! name, Microsoft.Extensions.VectorData.VectorStoreCollectionDefinition? definition = null, Weaviate.Client.VectorData.WeaviateVectorStoreCollectionOptions? options = null) -> void
 Weaviate.Client.VectorData.WeaviateVectorStoreCollectionOptions
 Weaviate.Client.VectorData.WeaviateVectorStoreCollectionOptions.ConsistencyLevel.get -> Weaviate.Client.ConsistencyLevels?

--- a/src/Weaviate.Client.VectorData/WeaviateVectorStoreCollection.cs
+++ b/src/Weaviate.Client.VectorData/WeaviateVectorStoreCollection.cs
@@ -297,7 +297,7 @@ public class WeaviateVectorStoreCollection<TKey, TRecord> : VectorStoreCollectio
     }
 
     /// <inheritdoc />
-    public new async IAsyncEnumerable<VectorSearchResult<TRecord>> HybridSearchAsync<TInput>(
+    public async IAsyncEnumerable<VectorSearchResult<TRecord>> HybridSearchAsync<TInput>(
         TInput searchValue,
         ICollection<string> keywords,
         int top,

--- a/src/Weaviate.Client/Batch/README.md
+++ b/src/Weaviate.Client/Batch/README.md
@@ -30,7 +30,7 @@ Manages the lifecycle and state of a batch, including adding objects, retrying, 
 - `Close(CancellationToken)` - Close the batch and wait for all results
 
 **Properties:**
-- `State` - Current `BatchState` (Open, InFlight, Closed, Aborted)
+- `State` - Current `BatchState` (Open, InFlight, Closed)
 
 ### `TaskHandle`
 

--- a/src/Weaviate.Client/Models/BackupOperationBase.cs
+++ b/src/Weaviate.Client/Models/BackupOperationBase.cs
@@ -34,17 +34,17 @@ public abstract class BackupOperationBase : IDisposable, IAsyncDisposable
     /// <summary>
     /// The is completed
     /// </summary>
-    private bool _isCompleted;
+    private volatile bool _isCompleted;
 
     /// <summary>
     /// The is successful
     /// </summary>
-    private bool _isSuccessful;
+    private volatile bool _isSuccessful;
 
     /// <summary>
     /// The is canceled
     /// </summary>
-    private bool _isCanceled;
+    private volatile bool _isCanceled;
 
     /// <summary>
     /// The disposed
@@ -97,6 +97,8 @@ public abstract class BackupOperationBase : IDisposable, IAsyncDisposable
     /// </summary>
     private Task StartBackgroundRefresh()
     {
+        if (_isCompleted)
+            return Task.CompletedTask;
         return Task.Run(async () =>
         {
             while (!_isCompleted && !_cts.IsCancellationRequested)
@@ -110,10 +112,7 @@ public abstract class BackupOperationBase : IDisposable, IAsyncDisposable
                 {
                     break;
                 }
-                catch
-                {
-                    // Swallow errors, optionally log
-                }
+                catch { }
             }
         });
     }
@@ -135,10 +134,7 @@ public abstract class BackupOperationBase : IDisposable, IAsyncDisposable
             _isCompleted = true;
             _isSuccessful = status.Status == BackupStatus.Success;
             _isCanceled = status.Status == BackupStatus.Canceled;
-            await _cts.CancelAsync(); // Stop background polling
-
-            // Auto-dispose resources now that operation is complete
-            // This prevents resource leaks if caller forgets to dispose
+            await _cts.CancelAsync();
             DisposeInternal();
         }
     }
@@ -157,13 +153,14 @@ public abstract class BackupOperationBase : IDisposable, IAsyncDisposable
         var effectiveTimeout = timeout ?? BackupClient.Config.Timeout;
         var start = DateTime.UtcNow;
 
-        var effectiveToken = CancellationTokenSource
-            .CreateLinkedTokenSource(_cts.Token, cancellationToken)
-            .Token;
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            _cts.Token,
+            cancellationToken
+        );
+        var effectiveToken = linkedCts.Token;
 
         while (!_isCompleted && !effectiveToken.IsCancellationRequested)
         {
-            effectiveToken.ThrowIfCancellationRequested();
             if (DateTime.UtcNow - start > effectiveTimeout)
             {
                 throw new TimeoutException(
@@ -174,10 +171,7 @@ public abstract class BackupOperationBase : IDisposable, IAsyncDisposable
             {
                 await Task.Delay(BackupClient.Config.PollInterval, effectiveToken);
             }
-            catch (OperationCanceledException) when (_isCompleted)
-            {
-                // Operation completed while waiting
-            }
+            catch (OperationCanceledException) when (_isCompleted) { }
         }
         return _current;
     }
@@ -187,7 +181,6 @@ public abstract class BackupOperationBase : IDisposable, IAsyncDisposable
     /// </summary>
     public async Task Cancel(CancellationToken cancellationToken = default)
     {
-        // Call server-side Cancel
         await _operationCancel(cancellationToken);
 
         await RefreshStatusInternal(cancellationToken);
@@ -207,10 +200,7 @@ public abstract class BackupOperationBase : IDisposable, IAsyncDisposable
             {
                 _backgroundRefreshTask.Wait(BackupClient.Config.PollInterval);
             }
-            catch (Exception)
-            {
-                // Ignore exceptions from waiting on background task, as disposal is best-effort
-            }
+            catch (Exception) { }
             _cts.Dispose();
         }
         _disposed = true;
@@ -226,13 +216,9 @@ public abstract class BackupOperationBase : IDisposable, IAsyncDisposable
 
         try
         {
-            // Wait for background task to complete (should be immediate since we just canceled)
             _backgroundRefreshTask.Wait(BackupClient.Config.PollInterval);
         }
-        catch (Exception)
-        {
-            // Ignore exceptions, disposal is best-effort
-        }
+        catch (Exception) { }
 
         _cts.Dispose();
         _disposed = true;
@@ -258,13 +244,9 @@ public abstract class BackupOperationBase : IDisposable, IAsyncDisposable
 
         try
         {
-            // Await the background task gracefully
             await _backgroundRefreshTask.ConfigureAwait(false);
         }
-        catch (Exception)
-        {
-            // Ignore exceptions, disposal is best-effort
-        }
+        catch (Exception) { }
 
         _cts.Dispose();
         _disposed = true;

--- a/src/Weaviate.Client/PublicAPI.Unshipped.txt
+++ b/src/Weaviate.Client/PublicAPI.Unshipped.txt
@@ -6794,7 +6794,6 @@ Weaviate.Client.Batch.BatchResult.ErrorMessage.get -> string?
 Weaviate.Client.Batch.BatchResult.ServerResponse.get -> object?
 Weaviate.Client.Batch.BatchResult.Success.get -> bool
 Weaviate.Client.Batch.BatchState
-Weaviate.Client.Batch.BatchState.Aborted = 3 -> Weaviate.Client.Batch.BatchState
 Weaviate.Client.Batch.BatchState.Closed = 2 -> Weaviate.Client.Batch.BatchState
 Weaviate.Client.Batch.BatchState.InFlight = 1 -> Weaviate.Client.Batch.BatchState
 Weaviate.Client.Batch.BatchState.Open = 0 -> Weaviate.Client.Batch.BatchState


### PR DESCRIPTION
## Summary

Five small fixes carved out of #324 (Collection Export) so that PR can shrink to export-only. Each fix is independent and unrelated to the export feature itself; they had drifted into the export branch over the course of development. Splitting them out per @dirkkul's review on #324 (\`why this change?\` on \`Batch/README.md\`, \`unrelated change?\` on \`TestReplication.cs\`).

## Commits

- \`test(replication)\`: layer a further de-flake on top of #325 — treat \`ScheduledForDelete\` ops as already deleted instead of waiting for the row to disappear from \`ListAll\`.
- \`fix(batch)\`: drop phantom \`BatchState.Aborted\` from \`Batch/README.md\`, \`docs/BATCH_API_USAGE.md\`, and \`PublicAPI.Unshipped.txt\`. The enum has only had \`Open\`/\`InFlight\`/\`Closed\` since #305 — the \`Aborted = 3\` entry has been triggering RS0017 on main.
- \`refactor(backup)\`: mark \`_isCompleted\`/\`_isSuccessful\`/\`_isCanceled\` \`volatile\`, and fix a leaking linked \`CancellationTokenSource\` in \`WaitForCompletionInternal\` by scoping it with \`using var\`. Plus minor cleanup. No public-API change.
- \`fix(vectordata)\`: drop stale \`new\` modifier on \`WeaviateVectorStoreCollection.HybridSearchAsync<TInput>\` — the base \`VectorStoreCollection\` has no overload to shadow.
- \`docs\`: add \"REST DTO Generation\" section to \`CLAUDE.md\` documenting the \`tools/openapi_sync.sh\` + \`tools/gen_rest_dto.sh\` regeneration pipeline and Liquid template overrides.

## Test plan

- [x] \`dotnet build Weaviate.sln\` clean (0 errors; the 126 RS0016 warnings are pre-existing on main, unrelated to this branch).
- [x] \`dotnet test --filter \"FullyQualifiedName~Unit\"\` → 820 passed, 0 failed.
- [x] pre-commit (\`dotnet-build\` + CSharpier) passed on every commit.
- [ ] CI integration suite — verify \`Test_DeleteAll_Operations\` is stable across Weaviate version matrix.

## Follow-up

After this lands, #324 will be rebased onto main so its diff is export-only, and the \`fileType\` / \`Delete-on-409\` review fixes will be applied there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)