### PR TITLE
fix(backup): plug disposal leaks in BackupOperationBase / BackupClient

### DIFF
--- a/src/Weaviate.Client/BackupClient.cs
+++ b/src/Weaviate.Client/BackupClient.cs
@@ -90,7 +90,7 @@ public class BackupClient
         CancellationToken cancellationToken = default
     )
     {
-        var operation = await Create(request, cancellationToken);
+        await using var operation = await Create(request, cancellationToken);
         return await operation.WaitForCompletion(timeout, cancellationToken);
     }
 
@@ -277,7 +277,7 @@ public class BackupClient
         CancellationToken cancellationToken = default
     )
     {
-        var operation = await Restore(request, cancellationToken);
+        await using var operation = await Restore(request, cancellationToken);
         return await operation.WaitForCompletion(timeout, cancellationToken);
     }
 

--- a/src/Weaviate.Client/Models/BackupOperationBase.cs
+++ b/src/Weaviate.Client/Models/BackupOperationBase.cs
@@ -207,19 +207,16 @@ public abstract class BackupOperationBase : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// Internal disposal logic that can be called from background task without re-entrancy issues.
+    /// Internal disposal called from the background refresh task itself when a terminal status
+    /// is observed. Must NOT Wait() on _backgroundRefreshTask — that would block the very task
+    /// executing this code on its own completion (bounded only by the Wait timeout). The task
+    /// is already exiting because _cts has been canceled and _isCompleted is set, so just
+    /// release the CTS.
     /// </summary>
     private void DisposeInternal()
     {
         if (_disposed)
             return;
-
-        try
-        {
-            _backgroundRefreshTask.Wait(BackupClient.Config.PollInterval);
-        }
-        catch (Exception) { }
-
         _cts.Dispose();
         _disposed = true;
     }


### PR DESCRIPTION
## Summary

Two pre-existing disposal issues in the backup polling subsystem, surfaced during review of #324 (Collection Export). Pulled into a separate PR so #324 can stay focused on the export feature itself.

## Commits

1. \`fix(backup): drop self-Wait in BackupOperationBase.DisposeInternal\`
   \`DisposeInternal\` is invoked from \`RefreshStatusInternal\`, which itself runs inside \`_backgroundRefreshTask\`. Calling \`_backgroundRefreshTask.Wait(...)\` from there blocks the very task executing the call on its own completion — only the \`Wait\` timeout (\`PollInterval\`, default 250ms) breaks the stall. Net effect: every successful auto-disposal stalls the polling thread for ~250ms. Drop the self-Wait; the task is already exiting (\`_isCompleted\` set, \`_cts\` canceled) so disposing \`_cts\` is enough. External \`Dispose(bool)\` / \`DisposeAsync\` are unchanged — they correctly Wait/await from outside the task.

2. \`fix(backup): await using operation in CreateSync and RestoreSync\`
   \`CreateSync\` / \`RestoreSync\` awaited \`Create\`/\`Restore\` to obtain the operation handle, then awaited \`WaitForCompletion\`. If \`WaitForCompletion\` threw (timeout, cancellation, server error), the operation — owning a CTS and a background polling task — was never disposed. Wrap in \`await using\` so disposal runs on every exit path.

## Test plan

- [x] \`dotnet build Weaviate.sln\` clean (0 errors).
- [x] \`dotnet test --filter Unit\` → 820 passed, 0 failed (no behaviour change for terminal-status detection).
- [ ] Integration suite — should be unaffected; the disposal fix only saves ~250ms in auto-cleanup, the \`await using\` only matters when an exception is thrown.

## Follow-up

After this lands, #324 will be rebased onto main and the same two fixes ported into \`ExportOperationBase\` / \`ExportClient\` (export was directly modeled on this pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)