### PR TITLE
test: honor WV_HTTP_PORT/WV_GRPC_PORT in ClientTests and TestAuth

### DIFF
--- a/src/Weaviate.Client.Tests/Integration/TestAuth.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestAuth.cs
@@ -8,7 +8,6 @@ using Weaviate.Client;
 
 public class TestAuth : IntegrationTests
 {
-    const int ANON_PORT = 8080;
     const int OKTA_PORT_CC = 8082;
     const int OKTA_PORT_USERS = 8083;
 
@@ -133,11 +132,12 @@ public class TestAuth : IntegrationTests
     [Fact]
     public async Task TestClientWithAuthenticationWithAnonWeaviate()
     {
-        Assert.False(await IsAuthEnabled($"localhost:{ANON_PORT}"));
+        Assert.False(await IsAuthEnabled($"localhost:{RestPort}"));
 
         var client = await Connect.Local(
             hostname: "localhost",
-            restPort: ANON_PORT,
+            restPort: RestPort,
+            grpcPort: GrpcPort,
             credentials: Auth.ClientPassword(
                 username: "someUser",
                 password: "SomePw",

--- a/src/Weaviate.Client.Tests/Integration/TestClient.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestClient.cs
@@ -13,7 +13,7 @@ public partial class ClientTests : IntegrationTests
     [Fact]
     public async Task ConnectToLocal()
     {
-        var client = await Connect.Local();
+        var client = await Connect.Local(restPort: RestPort, grpcPort: GrpcPort);
 
         var ex = await Record.ExceptionAsync(async () =>
             await client
@@ -49,11 +49,14 @@ public partial class ClientTests : IntegrationTests
     [Fact]
     public async Task TestMeta()
     {
-        var client = await Connect.Local();
+        var client = await Connect.Local(restPort: RestPort, grpcPort: GrpcPort);
         var meta = await client.GetMeta(TestContext.Current.CancellationToken);
 
         // ip is different depending on the environment
-        Assert.Contains("8080", meta.Hostname);
+        Assert.Contains(
+            RestPort.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            meta.Hostname
+        );
         Assert.Contains("http://", meta.Hostname);
     }
 


### PR DESCRIPTION
## Summary

Three integration tests bypass the `WV_HTTP_PORT` / `WV_GRPC_PORT` env vars that the rest of the suite honors via `IntegrationTests.RestPort` / `GrpcPort`:

- `ClientTests::ConnectToLocal`
- `ClientTests::TestMeta`
- `TestAuth::TestClientWithAuthenticationWithAnonWeaviate`

They call `Connect.Local()` (or with `ANON_PORT = 8080`) without forwarding the configured ports, so they always hit `localhost:8080`.

This breaks any setup where Weaviate isn't on the default ports — including the parity-testing stack on the Weaviate server side (where `weaviate-dev` runs on 8090 and the proxy stack on 9080), and likely any reverse-proxy/devcontainer/multi-instance setup.

Found while running this repo's integration suite against a parity test rig in `weaviate/weaviate#feat/apache-arrow`. The 3 tests were the only "failures" attributable to client code rather than a real product bug — fixing them removes 3 false-positives from the parity comparison.

## Changes

- `TestClient.cs`: forward `RestPort` / `GrpcPort` to `Connect.Local()` in `ConnectToLocal` and `TestMeta`. In `TestMeta`, assert against `RestPort.ToString(...)` instead of the hardcoded string `"8080"`.
- `TestAuth.cs`: drop the unused `ANON_PORT = 8080` constant; `TestClientWithAuthenticationWithAnonWeaviate` now uses `RestPort` / `GrpcPort` from the base class.

No production code changes — tests only.

## Test plan

- [ ] Default ports: `dotnet test --filter "FullyQualifiedName~ConnectToLocal|FullyQualifiedName~TestMeta|FullyQualifiedName~TestClientWithAuthenticationWithAnonWeaviate"` against a default-port Weaviate still passes.
- [ ] Non-default ports: `WV_HTTP_PORT=8090 WV_GRPC_PORT=50051 dotnet test ...` against a Weaviate on those ports passes (currently fails on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)