### PR TITLE
feat: add blobHash property type support (Weaviate 1.37.0+)

### DIFF
--- a/src/Weaviate.Client.Tests/Integration/TestProperties.cs
+++ b/src/Weaviate.Client.Tests/Integration/TestProperties.cs
@@ -943,4 +943,28 @@ public partial class PropertyTests : IntegrationTests
             );
         }
     }
+
+    /// <summary>
+    /// Tests that a collection with a blobHash property can be created and the schema
+    /// round-trips correctly through the API (data type serialized and deserialized).
+    /// </summary>
+    [Fact]
+    public async Task BlobHash_SchemaRoundTrip_DataTypePreserved()
+    {
+        RequireVersion("1.37.0");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var c = await CollectionFactory(
+            description: "Testing blobHash property schema round-trip",
+            properties: [Property.BlobHash("imageHash")]
+        );
+
+        var config = await c.Config.Get(cancellationToken: ct);
+
+        Assert.NotNull(config);
+        var prop = config?.Properties?.FirstOrDefault(p => p.Name == "imageHash");
+        Assert.NotNull(prop);
+        Assert.Equal(DataType.BlobHash, prop.DataType);
+    }
 }

--- a/src/Weaviate.Client.Tests/Unit/TestPropertyConverters.cs
+++ b/src/Weaviate.Client.Tests/Unit/TestPropertyConverters.cs
@@ -322,6 +322,55 @@ public class TestPropertyConverters
 
     #endregion
 
+    #region BlobHashPropertyConverter Tests
+
+    /// <summary>
+    /// Tests that blob hash converter to rest returns string
+    /// </summary>
+    [Fact]
+    public void BlobHashConverter_ToRest_ReturnsString()
+    {
+        var converter = new BlobHashPropertyConverter();
+        var hash = "abc123def456";
+        var result = converter.ToRest(hash);
+        Assert.Equal(hash, result);
+    }
+
+    /// <summary>
+    /// Tests that blob hash converter from rest returns string
+    /// </summary>
+    [Fact]
+    public void BlobHashConverter_FromRest_ReturnsString()
+    {
+        var converter = new BlobHashPropertyConverter();
+        var hash = "abc123def456";
+        var result = converter.FromRest(hash, typeof(string));
+        Assert.IsType<string>(result);
+        Assert.Equal(hash, result);
+    }
+
+    /// <summary>
+    /// Tests that blob hash converter does not support array
+    /// </summary>
+    [Fact]
+    public void BlobHashConverter_DoesNotSupportArray()
+    {
+        var converter = new BlobHashPropertyConverter();
+        Assert.False(converter.SupportsArray);
+    }
+
+    /// <summary>
+    /// Tests that blob hash converter has correct data type
+    /// </summary>
+    [Fact]
+    public void BlobHashConverter_HasCorrectDataType()
+    {
+        var converter = new BlobHashPropertyConverter();
+        Assert.Equal("blobHash", converter.DataType);
+    }
+
+    #endregion
+
     #region GeoPropertyConverter Tests
 
     /// <summary>
@@ -435,6 +484,7 @@ public class TestPropertyConverters
         Assert.IsType<DatePropertyConverter>(registry.GetConverterByDataType("date"));
         Assert.IsType<UuidPropertyConverter>(registry.GetConverterByDataType("uuid"));
         Assert.IsType<BlobPropertyConverter>(registry.GetConverterByDataType("blob"));
+        Assert.IsType<BlobHashPropertyConverter>(registry.GetConverterByDataType("blobHash"));
         Assert.IsType<GeoPropertyConverter>(registry.GetConverterByDataType("geoCoordinates"));
         Assert.IsType<PhonePropertyConverter>(registry.GetConverterByDataType("phoneNumber"));
     }

--- a/src/Weaviate.Client/Internal/Serialization/Converters/BlobHashPropertyConverter.cs
+++ b/src/Weaviate.Client/Internal/Serialization/Converters/BlobHashPropertyConverter.cs
@@ -1,0 +1,85 @@
+using Google.Protobuf.WellKnownTypes;
+
+namespace Weaviate.Client.Serialization.Converters;
+
+/// <summary>
+/// Converter for Weaviate "blobHash" data type (no array variant).
+/// Stores the hash of a blob as a string instead of the blob data itself.
+/// </summary>
+internal class BlobHashPropertyConverter : PropertyConverterBase
+{
+    /// <summary>
+    /// Gets the value of the data type
+    /// </summary>
+    public override string DataType => "blobHash";
+
+    /// <summary>
+    /// Gets the value of the supports array
+    /// </summary>
+    public override bool SupportsArray => false;
+
+    /// <summary>
+    /// Gets the value of the supported types.
+    /// Empty to avoid conflicting with TextPropertyConverter for string lookups.
+    /// </summary>
+    public override IReadOnlyList<System.Type> SupportedTypes => [];
+
+    /// <summary>
+    /// Returns the rest using the specified value
+    /// </summary>
+    /// <param name="value">The value</param>
+    /// <returns>The object</returns>
+    public override object? ToRest(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            string s => s,
+            _ => value.ToString(),
+        };
+    }
+
+    /// <summary>
+    /// Returns the grpc using the specified value
+    /// </summary>
+    /// <param name="value">The value</param>
+    /// <returns>The value</returns>
+    public override Value ToGrpc(object? value)
+    {
+        if (value is null)
+            return Value.ForNull();
+
+        if (value is string s)
+            return Value.ForString(s);
+
+        return Value.ForNull();
+    }
+
+    /// <summary>
+    /// Creates the rest using the specified value
+    /// </summary>
+    /// <param name="value">The value</param>
+    /// <param name="targetType">The target type</param>
+    /// <returns>The object</returns>
+    public override object? FromRest(object? value, System.Type targetType)
+    {
+        if (value is null)
+            return null;
+
+        return value.ToString();
+    }
+
+    /// <summary>
+    /// Creates the grpc using the specified value
+    /// </summary>
+    /// <param name="value">The value</param>
+    /// <param name="targetType">The target type</param>
+    /// <returns>The object</returns>
+    public override object? FromGrpc(Value value, System.Type targetType)
+    {
+        if (value.KindCase == Value.KindOneofCase.NullValue)
+            return null;
+
+        return value.StringValue;
+    }
+}

--- a/src/Weaviate.Client/Internal/Serialization/PropertyBag.cs
+++ b/src/Weaviate.Client/Internal/Serialization/PropertyBag.cs
@@ -167,6 +167,18 @@ public class PropertyBag : IDictionary<string, object?>
     }
 
     /// <summary>
+    /// Gets a blob hash (string) value by property name.
+    /// </summary>
+    public string? GetBlobHash(string name)
+    {
+        if (!TryGetValue(name, out var value) || value is null)
+            return null;
+
+        var converter = PropertyConverterRegistry.Default.GetConverterByDataType("blobHash");
+        return (string?)converter?.FromRest(value, typeof(string));
+    }
+
+    /// <summary>
     /// Gets an array of strings by property name.
     /// </summary>
     public string[]? GetStringArray(string name)

--- a/src/Weaviate.Client/Internal/Serialization/PropertyConverterRegistry.cs
+++ b/src/Weaviate.Client/Internal/Serialization/PropertyConverterRegistry.cs
@@ -63,6 +63,7 @@ internal class PropertyConverterRegistry
 
         // Special converters (no array support)
         registry.Register(new BlobPropertyConverter());
+        registry.Register(new BlobHashPropertyConverter());
         registry.Register(new GeoPropertyConverter());
         registry.Register(new PhonePropertyConverter());
 

--- a/src/Weaviate.Client/Models/Property.cs
+++ b/src/Weaviate.Client/Models/Property.cs
@@ -440,6 +440,10 @@ public enum DataType
     /// <summary>Object array data type.</summary>
     [System.Text.Json.Serialization.JsonStringEnumMemberName("object[]")]
     ObjectArray,
+
+    /// <summary>Blob hash data type. Stores the hash of a blob instead of the blob data itself.</summary>
+    [System.Text.Json.Serialization.JsonStringEnumMemberName("blobHash")]
+    BlobHash,
 }
 
 /// <summary>
@@ -663,6 +667,9 @@ public record Property : IEquatable<Property>
 
     /// <summary>Gets a factory for creating object array properties.</summary>
     public static PropertyFactory ObjectArray => PropertyHelper.Factory(DataType.ObjectArray);
+
+    /// <summary>Gets a factory for creating blob hash properties.</summary>
+    public static PropertyFactory BlobHash => PropertyHelper.Factory(DataType.BlobHash);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Property"/> class.

--- a/src/Weaviate.Client/Models/Property.cs
+++ b/src/Weaviate.Client/Models/Property.cs
@@ -441,7 +441,7 @@ public enum DataType
     [System.Text.Json.Serialization.JsonStringEnumMemberName("object[]")]
     ObjectArray,
 
-    /// <summary>Blob hash data type. Stores the hash of a blob instead of the blob data itself.</summary>
+    /// <summary>Blob hash data type. Stores the hash of a blob instead of the blob data itself. Introduced in Weaviate v1.37.</summary>
     [System.Text.Json.Serialization.JsonStringEnumMemberName("blobHash")]
     BlobHash,
 }

--- a/src/Weaviate.Client/PublicAPI.Unshipped.txt
+++ b/src/Weaviate.Client/PublicAPI.Unshipped.txt
@@ -1672,6 +1672,7 @@ static Weaviate.Client.Models.PhoneNumber.FromNational(string! country, string! 
 static Weaviate.Client.Models.PhoneNumber.operator !=(Weaviate.Client.Models.PhoneNumber? left, Weaviate.Client.Models.PhoneNumber? right) -> bool
 static Weaviate.Client.Models.PhoneNumber.operator ==(Weaviate.Client.Models.PhoneNumber? left, Weaviate.Client.Models.PhoneNumber? right) -> bool
 static Weaviate.Client.Models.Property.Blob.get -> Weaviate.Client.Models.PropertyFactory!
+static Weaviate.Client.Models.Property.BlobHash.get -> Weaviate.Client.Models.PropertyFactory!
 static Weaviate.Client.Models.Property.Bool.get -> Weaviate.Client.Models.PropertyFactory!
 static Weaviate.Client.Models.Property.BoolArray.get -> Weaviate.Client.Models.PropertyFactory!
 static Weaviate.Client.Models.Property.Date.get -> Weaviate.Client.Models.PropertyFactory!
@@ -3654,6 +3655,7 @@ Weaviate.Client.Models.DataResource.Tenant.get -> string?
 Weaviate.Client.Models.DataResource.Tenant.init -> void
 Weaviate.Client.Models.DataType
 Weaviate.Client.Models.DataType.Blob = 14 -> Weaviate.Client.Models.DataType
+Weaviate.Client.Models.DataType.BlobHash = 18 -> Weaviate.Client.Models.DataType
 Weaviate.Client.Models.DataType.Bool = 5 -> Weaviate.Client.Models.DataType
 Weaviate.Client.Models.DataType.BoolArray = 6 -> Weaviate.Client.Models.DataType
 Weaviate.Client.Models.DataType.Date = 9 -> Weaviate.Client.Models.DataType
@@ -6412,6 +6414,7 @@ Weaviate.Client.Serialization.PropertyBag.CopyTo(System.Collections.Generic.KeyV
 Weaviate.Client.Serialization.PropertyBag.Count.get -> int
 Weaviate.Client.Serialization.PropertyBag.GetAs<T>(string! name) -> T?
 Weaviate.Client.Serialization.PropertyBag.GetBlob(string! name) -> byte[]?
+Weaviate.Client.Serialization.PropertyBag.GetBlobHash(string! name) -> string?
 Weaviate.Client.Serialization.PropertyBag.GetBool(string! name) -> bool?
 Weaviate.Client.Serialization.PropertyBag.GetDateTime(string! name) -> System.DateTime?
 Weaviate.Client.Serialization.PropertyBag.GetDouble(string! name) -> double?


### PR DESCRIPTION
## Summary

- Adds `DataType.BlobHash` enum value (wire: `"blobHash"`) and `Property.BlobHash` static factory
- Adds `BlobHashPropertyConverter` — string passthrough, no array support, not registered by C# type to avoid shadowing `TextPropertyConverter`
- Adds `PropertyBag.GetBlobHash(string name) -> string?` for reading the stored SHA-256 hex hash

## Background

`blobHash` (introduced in Weaviate 1.37.0) accepts a base64-encoded blob on write, but the server computes a SHA-256 hash server-side **after** vectorization and stores only the 64-char hex digest. This reduces disk footprint for multimodal workloads where you want to track blob identity without storing the full payload.

Wire format: both `blob` and `blobHash` share the `blob_value` field in the gRPC proto — on write the client sends base64, on read the server returns the SHA-256 hex string.

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)