### PR TITLE
Add text2vec-digitalocean vectorizer module

### DIFF
--- a/src/Weaviate.Client.Tests/Unit/TestVectorizers.cs
+++ b/src/Weaviate.Client.Tests/Unit/TestVectorizers.cs
@@ -431,8 +431,8 @@ public partial class VectorConfigListTests
             "default",
             v =>
                 v.Text2VecDigitalOcean(
-                    baseURL: "https://inference.do-ai.run",
                     model: "qwen3-embedding-0.6b",
+                    baseURL: "https://inference.do-ai.run",
                     vectorizeCollectionName: false
                 )
         );
@@ -457,7 +457,8 @@ public partial class VectorConfigListTests
 
     /// <summary>
     /// Tests that Text2VecDigitalOcean omits unset optional fields so the server can apply
-    /// its defaults (no <c>baseURL</c>, no <c>model</c>).
+    /// its defaults (no <c>baseURL</c>). <c>model</c> is required by the factory so it is
+    /// always present.
     /// </summary>
     [Fact]
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
@@ -465,10 +466,13 @@ public partial class VectorConfigListTests
         "CA1869:Cache and reuse 'JsonSerializerOptions' instances",
         Justification = "<Pending>"
     )]
-    public void Test_Text2VecDigitalOcean_Omits_Unset_Optionals()
+    public void Test_Text2VecDigitalOcean_Omits_Unset_BaseURL()
     {
         // Arrange
-        var vc = Configure.Vector("default", v => v.Text2VecDigitalOcean());
+        var vc = Configure.Vector(
+            "default",
+            v => v.Text2VecDigitalOcean(model: "qwen3-embedding-0.6b")
+        );
 
         // Act
         var dto = vc.Vectorizer?.ToDto() ?? default;
@@ -489,7 +493,7 @@ public partial class VectorConfigListTests
 
         // Assert
         Assert.Contains("\"text2vec-digitalocean\"", json);
+        Assert.Contains("\"model\":\"qwen3-embedding-0.6b\"", json);
         Assert.DoesNotContain("\"baseURL\"", json);
-        Assert.DoesNotContain("\"model\"", json);
     }
 }

--- a/src/Weaviate.Client.Tests/Unit/TestVectorizers.cs
+++ b/src/Weaviate.Client.Tests/Unit/TestVectorizers.cs
@@ -413,4 +413,83 @@ public partial class VectorConfigListTests
         Assert.Contains("\"textFields\"", json);
         Assert.Contains("\"videoFields\"", json);
     }
+
+    /// <summary>
+    /// Tests that Text2VecDigitalOcean serializes baseURL and model correctly under the
+    /// <c>text2vec-digitalocean</c> module key.
+    /// </summary>
+    [Fact]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1869:Cache and reuse 'JsonSerializerOptions' instances",
+        Justification = "<Pending>"
+    )]
+    public void Test_Text2VecDigitalOcean_Serializes_BaseURL_And_Model()
+    {
+        // Arrange
+        var vc = Configure.Vector(
+            "default",
+            v =>
+                v.Text2VecDigitalOcean(
+                    baseURL: "https://inference.do-ai.run",
+                    model: "qwen3-embedding-0.6b",
+                    vectorizeCollectionName: false
+                )
+        );
+
+        // Act
+        var dto = vc.Vectorizer?.ToDto() ?? default;
+        var json = JsonSerializer.Serialize(
+            dto,
+            new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = false,
+            }
+        );
+
+        // Assert
+        Assert.Contains("\"text2vec-digitalocean\"", json);
+        Assert.Contains("\"baseURL\":\"https://inference.do-ai.run\"", json);
+        Assert.Contains("\"model\":\"qwen3-embedding-0.6b\"", json);
+        Assert.Contains("\"vectorizeClassName\":false", json);
+    }
+
+    /// <summary>
+    /// Tests that Text2VecDigitalOcean omits unset optional fields so the server can apply
+    /// its defaults (no <c>baseURL</c>, no <c>model</c>).
+    /// </summary>
+    [Fact]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1869:Cache and reuse 'JsonSerializerOptions' instances",
+        Justification = "<Pending>"
+    )]
+    public void Test_Text2VecDigitalOcean_Omits_Unset_Optionals()
+    {
+        // Arrange
+        var vc = Configure.Vector("default", v => v.Text2VecDigitalOcean());
+
+        // Act
+        var dto = vc.Vectorizer?.ToDto() ?? default;
+        var json = JsonSerializer.Serialize(
+            dto,
+            new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                DefaultIgnoreCondition = System
+                    .Text
+                    .Json
+                    .Serialization
+                    .JsonIgnoreCondition
+                    .WhenWritingNull,
+                WriteIndented = false,
+            }
+        );
+
+        // Assert
+        Assert.Contains("\"text2vec-digitalocean\"", json);
+        Assert.DoesNotContain("\"baseURL\"", json);
+        Assert.DoesNotContain("\"model\"", json);
+    }
 }

--- a/src/Weaviate.Client/Configure/VectorizerFactory.cs
+++ b/src/Weaviate.Client/Configure/VectorizerFactory.cs
@@ -751,6 +751,27 @@ public class VectorizerFactory
         };
 
     /// <summary>
+    /// Creates a configuration for the <c>text2vec-digitalocean</c> vectorizer.
+    /// See the <a href="https://weaviate.io/developers/weaviate/model-providers/digitalocean/embeddings">documentation</a>
+    /// for detailed usage.
+    /// </summary>
+    /// <param name="baseURL">The base URL where API requests should go. Defaults to <c>null</c>, which uses the server-defined default of <c>https://inference.do-ai.run</c>.</param>
+    /// <param name="model">The model to use, e.g. <c>qwen3-embedding-0.6b</c>. Required by the server.</param>
+    /// <param name="vectorizeCollectionName">Whether to vectorize the collection name.</param>
+    /// <returns>The vectorizer config</returns>
+    public VectorizerConfig Text2VecDigitalOcean(
+        string? baseURL = null,
+        string? model = null,
+        bool? vectorizeCollectionName = null
+    ) =>
+        new Text2VecDigitalOcean
+        {
+            BaseURL = baseURL,
+            Model = model,
+            VectorizeCollectionName = vectorizeCollectionName,
+        };
+
+    /// <summary>
     /// Texts the 2 vec model 2 vec using the specified inference url
     /// </summary>
     /// <param name="inferenceURL">The inference url</param>

--- a/src/Weaviate.Client/Configure/VectorizerFactory.cs
+++ b/src/Weaviate.Client/Configure/VectorizerFactory.cs
@@ -755,13 +755,13 @@ public class VectorizerFactory
     /// See the <a href="https://weaviate.io/developers/weaviate/model-providers/digitalocean/embeddings">documentation</a>
     /// for detailed usage.
     /// </summary>
-    /// <param name="baseURL">The base URL where API requests should go. Defaults to <c>null</c>, which uses the server-defined default of <c>https://inference.do-ai.run</c>.</param>
     /// <param name="model">The model to use, e.g. <c>qwen3-embedding-0.6b</c>. Required by the server.</param>
+    /// <param name="baseURL">The base URL where API requests should go. Defaults to <c>null</c>, which uses the server-defined default of <c>https://inference.do-ai.run</c>.</param>
     /// <param name="vectorizeCollectionName">Whether to vectorize the collection name.</param>
     /// <returns>The vectorizer config</returns>
     public VectorizerConfig Text2VecDigitalOcean(
+        string model,
         string? baseURL = null,
-        string? model = null,
         bool? vectorizeCollectionName = null
     ) =>
         new Text2VecDigitalOcean

--- a/src/Weaviate.Client/Models/Vectorizer.cs
+++ b/src/Weaviate.Client/Models/Vectorizer.cs
@@ -1065,6 +1065,39 @@ public static class Vectorizer
     }
 
     /// <summary>
+    /// The configuration for text vectorization using the DigitalOcean module.
+    /// See the <a href="https://weaviate.io/developers/weaviate/model-providers/digitalocean/embeddings">documentation</a>
+    /// for detailed usage.
+    /// </summary>
+    [Vectorizer("text2vec-digitalocean")]
+    public record Text2VecDigitalOcean : VectorizerConfig
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Text2VecDigitalOcean"/> class
+        /// </summary>
+        [JsonConstructor]
+        internal Text2VecDigitalOcean() { }
+
+        /// <summary>
+        /// Gets or sets the base URL where API requests should go.
+        /// Defaults to <c>null</c>, which uses the server-defined default of <c>https://inference.do-ai.run</c>.
+        /// </summary>
+        [JsonPropertyName("baseURL")]
+        public string? BaseURL { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets the model to use, e.g. <c>qwen3-embedding-0.6b</c>. Required by the server.
+        /// </summary>
+        public string? Model { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets the value of the vectorize collection name
+        /// </summary>
+        [JsonPropertyName("vectorizeClassName")]
+        public bool? VectorizeCollectionName { get; set; } = null;
+    }
+
+    /// <summary>
     /// The configuration for text vectorization using the Model2Vec module.
     /// See the documentation for detailed usage.
     /// </summary>

--- a/src/Weaviate.Client/PublicAPI.Unshipped.txt
+++ b/src/Weaviate.Client/PublicAPI.Unshipped.txt
@@ -17,4 +17,4 @@ Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.Model.set -> void
 Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.Text2VecDigitalOcean(Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean! original) -> void
 Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.VectorizeCollectionName.get -> bool?
 Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.VectorizeCollectionName.set -> void
-Weaviate.Client.VectorizerFactory.Text2VecDigitalOcean(string? baseURL = null, string? model = null, bool? vectorizeCollectionName = null) -> Weaviate.Client.Models.VectorizerConfig!
+Weaviate.Client.VectorizerFactory.Text2VecDigitalOcean(string! model, string? baseURL = null, bool? vectorizeCollectionName = null) -> Weaviate.Client.Models.VectorizerConfig!

--- a/src/Weaviate.Client/PublicAPI.Unshipped.txt
+++ b/src/Weaviate.Client/PublicAPI.Unshipped.txt
@@ -1,1 +1,20 @@
 #nullable enable
+override sealed Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.Equals(Weaviate.Client.Models.VectorizerConfig? other) -> bool
+override Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.<Clone>$() -> Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean!
+override Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.EqualityContract.get -> System.Type!
+override Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.Equals(object? obj) -> bool
+override Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.GetHashCode() -> int
+override Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.ToString() -> string!
+static Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.operator !=(Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean? left, Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean? right) -> bool
+static Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.operator ==(Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean? left, Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean? right) -> bool
+virtual Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.Equals(Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean? other) -> bool
+Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean
+Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.BaseURL.get -> string?
+Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.BaseURL.set -> void
+Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.Model.get -> string?
+Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.Model.set -> void
+Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.Text2VecDigitalOcean(Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean! original) -> void
+Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.VectorizeCollectionName.get -> bool?
+Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean.VectorizeCollectionName.set -> void
+Weaviate.Client.VectorizerFactory.Text2VecDigitalOcean(string? baseURL = null, string? model = null, bool? vectorizeCollectionName = null) -> Weaviate.Client.Models.VectorizerConfig!


### PR DESCRIPTION
## Summary

Adds support for the new `text2vec-digitalocean` vectorizer module. Mirrors `text2vec-mistral` (shared shape: `model` + `baseURL` + `vectorizeClassName`).

`model` is **required** by the factory — the server requires it, so the public API enforces it at the call site.

## API surface added

Public types / members (in `PublicAPI.Unshipped.txt`):

- `Weaviate.Client.Models.Vectorizer.Text2VecDigitalOcean` record
  - `BaseURL` (string?, JSON name `baseURL`) — optional; server defaults to `https://inference.do-ai.run`
  - `Model` (string?) — kept nullable on the record itself (matches the `Text2VecMistral` record) so deserialization works; required-ness is enforced at the factory entry point
  - `VectorizeCollectionName` (bool?, JSON name `vectorizeClassName`)
  - generated record members (`Equals`, `GetHashCode`, `<Clone>$`, equality operators, `EqualityContract`, copy ctor, `PrintMembers`, `ToString`)
- `Weaviate.Client.VectorizerFactory.Text2VecDigitalOcean(string! model, string? baseURL = null, bool? vectorizeCollectionName = null) -> VectorizerConfig` — `model` is the first parameter and required; `baseURL` and `vectorizeCollectionName` keep their defaults

19 entries total in `PublicAPI.Unshipped.txt`.

## Test plan

- [x] `dotnet build` clean (0 errors, PublicAPI analyzer satisfied — no `RS0016` for the new symbols)
- [x] Two unit tests in `VectorConfigListTests`:
  - `Test_Text2VecDigitalOcean_Serializes_BaseURL_And_Model` — full-payload serialization
  - `Test_Text2VecDigitalOcean_Omits_Unset_BaseURL` — verifies `baseURL` is omitted when unset (with `model` always present)
- [x] All tests in `VectorConfigListTests` pass

## Review-feedback changes

Second commit (`0885c2e`) makes `model` required on the factory, matching the Python sibling PR (weaviate/weaviate-python-client#2041) and the server contract. The PublicAPI signature was updated accordingly, and the second test was renamed/repurposed since "model is omitted when unset" no longer applies (it's required on the factory).

Closes #339

Sibling PR (Python): weaviate/weaviate-python-client#2041

🤖 Generated with [Claude Code](https://claude.com/claude-code)