### PR TITLE
feat: add optional location to text2vec-google vectorizer

### DIFF
--- a/src/Weaviate.Client.Tests/Unit/TestVectorizers.cs
+++ b/src/Weaviate.Client.Tests/Unit/TestVectorizers.cs
@@ -496,4 +496,41 @@ public partial class VectorConfigListTests
         Assert.Contains("\"model\":\"qwen3-embedding-0.6b\"", json);
         Assert.DoesNotContain("\"baseURL\"", json);
     }
+
+    /// <summary>
+    /// Tests that Text2VecGoogle omits <c>location</c> when unset so the server can apply its
+    /// default.
+    /// </summary>
+    [Fact]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1869:Cache and reuse 'JsonSerializerOptions' instances",
+        Justification = "<Pending>"
+    )]
+    public void Test_Text2VecGoogle_Omits_Unset_Location()
+    {
+        // Arrange
+        var vc = Configure.Vector("default", v => v.Text2VecGoogleVertex(projectId: "my-project"));
+
+        // Act
+        var dto = vc.Vectorizer?.ToDto() ?? default;
+        var json = JsonSerializer.Serialize(
+            dto,
+            new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                DefaultIgnoreCondition = System
+                    .Text
+                    .Json
+                    .Serialization
+                    .JsonIgnoreCondition
+                    .WhenWritingNull,
+                WriteIndented = false,
+            }
+        );
+
+        // Assert
+        Assert.Contains("\"text2vec-google\"", json);
+        Assert.DoesNotContain("\"location\"", json);
+    }
 }

--- a/src/Weaviate.Client/Configure/VectorizerFactory.cs
+++ b/src/Weaviate.Client/Configure/VectorizerFactory.cs
@@ -863,6 +863,7 @@ public class VectorizerFactory
     /// <param name="dimensions">The dimensions</param>
     /// <param name="taskType">The task type</param>
     /// <param name="vectorizeCollectionName">The vectorize collection name</param>
+    /// <param name="location">The Google Vertex AI region; optional, server-defaulted when null</param>
     /// <returns>The vectorizer config</returns>
     public VectorizerConfig Text2VecGoogleVertex(
         string? apiEndpoint = null,
@@ -871,7 +872,8 @@ public class VectorizerFactory
         string? titleProperty = null,
         int? dimensions = null,
         string? taskType = null,
-        bool? vectorizeCollectionName = null
+        bool? vectorizeCollectionName = null,
+        string? location = null
     ) =>
         new Text2VecGoogle
         {
@@ -882,6 +884,7 @@ public class VectorizerFactory
             Dimensions = dimensions,
             TaskType = taskType,
             VectorizeCollectionName = vectorizeCollectionName,
+            Location = location,
         };
 
     /// <summary>
@@ -909,6 +912,9 @@ public class VectorizerFactory
             Dimensions = dimensions,
             TaskType = taskType,
             VectorizeCollectionName = vectorizeCollectionName,
+            // Location (Vertex AI region) is not applicable to the Gemini
+            // (generative-language) API; left null so it is omitted on the wire.
+            Location = null,
         };
 
     /// <summary>

--- a/src/Weaviate.Client/Models/Vectorizer.cs
+++ b/src/Weaviate.Client/Models/Vectorizer.cs
@@ -1273,6 +1273,13 @@ public static class Vectorizer
         public string? TaskType { get; set; } = null;
 
         /// <summary>
+        /// Gets or sets the Google Vertex AI region.
+        /// Optional; when omitted the server applies its default.
+        /// Serialized as the lowercase <c>location</c> module-config key.
+        /// </summary>
+        public string? Location { get; set; } = null;
+
+        /// <summary>
         /// Gets or sets the value of the vectorize collection name
         /// </summary>
         [JsonPropertyName("vectorizeClassName")]

--- a/src/Weaviate.Client/PublicAPI.Unshipped.txt
+++ b/src/Weaviate.Client/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+*REMOVED*Weaviate.Client.VectorizerFactory.Text2VecGoogleVertex(string? apiEndpoint = null, string? model = null, string? projectId = null, string? titleProperty = null, int? dimensions = null, string? taskType = null, bool? vectorizeCollectionName = null) -> Weaviate.Client.Models.VectorizerConfig!
+Weaviate.Client.Models.Vectorizer.Text2VecGoogle.Location.get -> string?
+Weaviate.Client.Models.Vectorizer.Text2VecGoogle.Location.set -> void
+Weaviate.Client.VectorizerFactory.Text2VecGoogleVertex(string? apiEndpoint = null, string? model = null, string? projectId = null, string? titleProperty = null, int? dimensions = null, string? taskType = null, bool? vectorizeCollectionName = null, string? location = null) -> Weaviate.Client.Models.VectorizerConfig!


### PR DESCRIPTION
Adds an optional `location` parameter (Google Vertex AI region) to the `text2vec-google` vectorizer config. When unset it is omitted from the module config, so the server applies its default.

Closes #348