### PR TITLE
feat: add optional dimensions to text2vec-aws vectorizer

### DIFF
--- a/src/Weaviate.Client.Tests/Unit/TestVectorizers.cs
+++ b/src/Weaviate.Client.Tests/Unit/TestVectorizers.cs
@@ -496,4 +496,90 @@ public partial class VectorConfigListTests
         Assert.Contains("\"model\":\"qwen3-embedding-0.6b\"", json);
         Assert.DoesNotContain("\"baseURL\"", json);
     }
+
+    /// <summary>
+    /// Tests that Text2VecAWS serializes <c>dimensions</c> as a JSON number (not a string) when it
+    /// is set via the Bedrock factory.
+    /// </summary>
+    [Fact]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1869:Cache and reuse 'JsonSerializerOptions' instances",
+        Justification = "<Pending>"
+    )]
+    public void Test_Text2VecAWS_Serializes_Dimensions_When_Set()
+    {
+        // Arrange
+        var vc = Configure.Vector(
+            "default",
+            v =>
+                v.Text2VecAWSBedrock(
+                    region: "us-east-1",
+                    model: "amazon.titan-embed-text-v2:0",
+                    dimensions: 1024
+                )
+        );
+
+        // Act
+        var dto = vc.Vectorizer?.ToDto() ?? default;
+        var json = JsonSerializer.Serialize(
+            dto,
+            new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                DefaultIgnoreCondition = System
+                    .Text
+                    .Json
+                    .Serialization
+                    .JsonIgnoreCondition
+                    .WhenWritingNull,
+                WriteIndented = false,
+            }
+        );
+
+        // Assert
+        Assert.Contains("\"text2vec-aws\"", json);
+        Assert.Contains("\"dimensions\":1024", json);
+        Assert.DoesNotContain("\"dimensions\":\"1024\"", json);
+    }
+
+    /// <summary>
+    /// Tests that Text2VecAWS omits <c>dimensions</c> when it is unset so the server can apply its
+    /// default.
+    /// </summary>
+    [Fact]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1869:Cache and reuse 'JsonSerializerOptions' instances",
+        Justification = "<Pending>"
+    )]
+    public void Test_Text2VecAWS_Omits_Unset_Dimensions()
+    {
+        // Arrange
+        var vc = Configure.Vector(
+            "default",
+            v => v.Text2VecAWSSagemaker(region: "us-east-1", endpoint: "my-endpoint")
+        );
+
+        // Act
+        var dto = vc.Vectorizer?.ToDto() ?? default;
+        var json = JsonSerializer.Serialize(
+            dto,
+            new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                DefaultIgnoreCondition = System
+                    .Text
+                    .Json
+                    .Serialization
+                    .JsonIgnoreCondition
+                    .WhenWritingNull,
+                WriteIndented = false,
+            }
+        );
+
+        // Assert
+        Assert.Contains("\"text2vec-aws\"", json);
+        Assert.DoesNotContain("\"dimensions\"", json);
+    }
 }

--- a/src/Weaviate.Client/Configure/VectorizerFactory.cs
+++ b/src/Weaviate.Client/Configure/VectorizerFactory.cs
@@ -536,11 +536,13 @@ public class VectorizerFactory
     /// </summary>
     /// <param name="region">The region</param>
     /// <param name="model">The model</param>
+    /// <param name="dimensions">Number of vector dimensions.</param>
     /// <param name="vectorizeCollectionName">The vectorize collection name</param>
     /// <returns>The vectorizer config</returns>
     public VectorizerConfig Text2VecAWSBedrock(
         string region,
         string model,
+        int? dimensions = null,
         bool? vectorizeCollectionName = null
     ) =>
         new Text2VecAWS
@@ -551,6 +553,7 @@ public class VectorizerFactory
             Model = model,
             TargetModel = null,
             TargetVariant = null,
+            Dimensions = dimensions,
             VectorizeCollectionName = vectorizeCollectionName,
         };
 
@@ -561,6 +564,7 @@ public class VectorizerFactory
     /// <param name="endpoint">The endpoint</param>
     /// <param name="targetModel">The target model</param>
     /// <param name="targetVariant">The target variant</param>
+    /// <param name="dimensions">Number of vector dimensions.</param>
     /// <param name="vectorizeCollectionName">The vectorize collection name</param>
     /// <returns>The vectorizer config</returns>
     public VectorizerConfig Text2VecAWSSagemaker(
@@ -568,6 +572,7 @@ public class VectorizerFactory
         string endpoint,
         string? targetModel = null,
         string? targetVariant = null,
+        int? dimensions = null,
         bool? vectorizeCollectionName = null
     ) =>
         new Text2VecAWS
@@ -578,6 +583,7 @@ public class VectorizerFactory
             Model = null,
             TargetModel = targetModel,
             TargetVariant = targetVariant,
+            Dimensions = dimensions,
             VectorizeCollectionName = vectorizeCollectionName,
         };
 

--- a/src/Weaviate.Client/Models/Vectorizer.cs
+++ b/src/Weaviate.Client/Models/Vectorizer.cs
@@ -718,6 +718,11 @@ public static class Vectorizer
         public string? TargetVariant { get; set; } = null;
 
         /// <summary>
+        /// Gets or sets the value of the dimensions
+        /// </summary>
+        public int? Dimensions { get; set; } = null;
+
+        /// <summary>
         /// Gets or sets the value of the vectorize collection name
         /// </summary>
         [JsonPropertyName("vectorizeClassName")]

--- a/src/Weaviate.Client/PublicAPI.Unshipped.txt
+++ b/src/Weaviate.Client/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+*REMOVED*Weaviate.Client.VectorizerFactory.Text2VecAWSBedrock(string! region, string! model, bool? vectorizeCollectionName = null) -> Weaviate.Client.Models.VectorizerConfig!
+*REMOVED*Weaviate.Client.VectorizerFactory.Text2VecAWSSagemaker(string! region, string! endpoint, string? targetModel = null, string? targetVariant = null, bool? vectorizeCollectionName = null) -> Weaviate.Client.Models.VectorizerConfig!
+Weaviate.Client.Models.Vectorizer.Text2VecAWS.Dimensions.get -> int?
+Weaviate.Client.Models.Vectorizer.Text2VecAWS.Dimensions.set -> void
+Weaviate.Client.VectorizerFactory.Text2VecAWSBedrock(string! region, string! model, int? dimensions = null, bool? vectorizeCollectionName = null) -> Weaviate.Client.Models.VectorizerConfig!
+Weaviate.Client.VectorizerFactory.Text2VecAWSSagemaker(string! region, string! endpoint, string? targetModel = null, string? targetVariant = null, int? dimensions = null, bool? vectorizeCollectionName = null) -> Weaviate.Client.Models.VectorizerConfig!


### PR DESCRIPTION
Adds an optional `dimensions` parameter (output embedding dimensionality) to the `text2vec-aws` vectorizer config. Omitted when unset, so the server applies its default.

Closes #349