### PR TITLE
feat: add endpoint setting for text2vec-openai/morph and location for generative-google

### DIFF
--- a/src/Weaviate.Client.Tests/Unit/TestCollection.cs
+++ b/src/Weaviate.Client.Tests/Unit/TestCollection.cs
@@ -349,6 +349,46 @@ public class CollectionTests
     }
 
     /// <summary>
+    /// Tests that GoogleVertex generative config serializes <c>location</c> when set, omits it
+    /// when unset, and round-trips it.
+    /// </summary>
+    [Fact]
+    public void Collection_GenerativeGoogleVertex_Serializes_And_RoundTrips_Location()
+    {
+        // Arrange
+        var withLocation = Assert.IsType<GenerativeConfig.GoogleVertex>(
+            Configure.Generative.GoogleVertex(projectId: "my-project", location: "us-east4")
+        );
+        var withoutLocation = Assert.IsType<GenerativeConfig.GoogleVertex>(
+            Configure.Generative.GoogleVertex(projectId: "my-project")
+        );
+
+        // Act
+        var jsonWith = JsonSerializer.Serialize(
+            withLocation,
+            Rest.WeaviateRestClient.RestJsonSerializerOptions
+        );
+        var jsonWithout = JsonSerializer.Serialize(
+            withoutLocation,
+            Rest.WeaviateRestClient.RestJsonSerializerOptions
+        );
+
+        // Assert
+        Assert.Contains("\"location\":\"us-east4\"", jsonWith);
+        Assert.DoesNotContain("\"location\"", jsonWithout);
+
+        var roundTripped = GenerativeConfigSerialization.Factory(
+            GenerativeConfig.GoogleVertex.TypeValue,
+            JsonSerializer.Deserialize<object>(
+                jsonWith,
+                Rest.WeaviateRestClient.RestJsonSerializerOptions
+            )
+        );
+        var typed = Assert.IsType<GenerativeConfig.GoogleVertex>(roundTripped);
+        Assert.Equal("us-east4", typed.Location);
+    }
+
+    /// <summary>
     /// Tests that collection rerank deserializes into i reranker config
     /// </summary>
     [Fact]

--- a/src/Weaviate.Client.Tests/Unit/TestGenerativeShortcuts.cs
+++ b/src/Weaviate.Client.Tests/Unit/TestGenerativeShortcuts.cs
@@ -86,6 +86,69 @@ public class GenerativeShortcutsTests
     }
 
     /// <summary>
+    /// Tests that the GoogleVertex provider maps <c>Location</c> onto the gRPC message.
+    /// </summary>
+    [Fact]
+    public async Task GenerateClient_FetchObjects_WithGoogleVertexProvider_MapsLocation()
+    {
+        // Arrange
+        var provider = new Providers.GoogleVertex
+        {
+            Model = "gemini-1.5-pro",
+            Location = "us-east4",
+        };
+        var (client, getCapturedRequest) = CreateClientWithRequestCapture();
+
+        // Act
+        await client
+            .Collections.Use("TestCollection")
+            .Generate.FetchObjects(
+                limit: 10,
+                singlePrompt: "Summarize this",
+                provider: provider,
+                cancellationToken: TestContext.Current.CancellationToken
+            );
+
+        // Assert
+        var capturedRequest = getCapturedRequest();
+        Assert.NotNull(capturedRequest);
+        Assert.NotNull(capturedRequest.Generative);
+        Assert.NotNull(capturedRequest.Generative.Single);
+        var providerQuery = capturedRequest.Generative.Single.Queries[0];
+        Assert.NotNull(providerQuery.Google);
+        Assert.Equal("gemini-1.5-pro", providerQuery.Google.Model);
+        Assert.Equal("us-east4", providerQuery.Google.Location);
+    }
+
+    /// <summary>
+    /// Tests that the GoogleVertex provider leaves <c>Location</c> empty when unset.
+    /// </summary>
+    [Fact]
+    public async Task GenerateClient_FetchObjects_WithGoogleVertexProvider_LeavesLocationEmptyWhenUnset()
+    {
+        // Arrange
+        var provider = new Providers.GoogleVertex { Model = "gemini-1.5-pro" };
+        var (client, getCapturedRequest) = CreateClientWithRequestCapture();
+
+        // Act
+        await client
+            .Collections.Use("TestCollection")
+            .Generate.FetchObjects(
+                limit: 10,
+                singlePrompt: "Summarize this",
+                provider: provider,
+                cancellationToken: TestContext.Current.CancellationToken
+            );
+
+        // Assert
+        var capturedRequest = getCapturedRequest();
+        Assert.NotNull(capturedRequest);
+        var providerQuery = capturedRequest!.Generative!.Single!.Queries[0];
+        Assert.NotNull(providerQuery.Google);
+        Assert.Equal(string.Empty, providerQuery.Google.Location);
+    }
+
+    /// <summary>
     /// Tests that generate client fetch objects with string grouped task and provider enriches task
     /// </summary>
     [Fact]

--- a/src/Weaviate.Client.Tests/Unit/TestVectorizers.cs
+++ b/src/Weaviate.Client.Tests/Unit/TestVectorizers.cs
@@ -619,4 +619,159 @@ public partial class VectorConfigListTests
         Assert.Contains("\"text2vec-aws\"", json);
         Assert.DoesNotContain("\"dimensions\"", json);
     }
+
+    /// <summary>
+    /// Tests that Text2VecOpenAI serializes <c>endpoint</c> when it is set.
+    /// </summary>
+    [Fact]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1869:Cache and reuse 'JsonSerializerOptions' instances",
+        Justification = "<Pending>"
+    )]
+    public void Test_Text2VecOpenAI_Serializes_Endpoint_When_Set()
+    {
+        // Arrange
+        var vc = Configure.Vector(
+            "default",
+            v => v.Text2VecOpenAI(model: "text-embedding-3-small", endpoint: "/v2/embeddings")
+        );
+
+        // Act
+        var dto = vc.Vectorizer?.ToDto() ?? default;
+        var json = JsonSerializer.Serialize(
+            dto,
+            new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                DefaultIgnoreCondition = System
+                    .Text
+                    .Json
+                    .Serialization
+                    .JsonIgnoreCondition
+                    .WhenWritingNull,
+                WriteIndented = false,
+            }
+        );
+
+        // Assert
+        Assert.Contains("\"text2vec-openai\"", json);
+        Assert.Contains("\"endpoint\":\"/v2/embeddings\"", json);
+    }
+
+    /// <summary>
+    /// Tests that Text2VecOpenAI omits <c>endpoint</c> when unset so the server can apply its
+    /// default.
+    /// </summary>
+    [Fact]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1869:Cache and reuse 'JsonSerializerOptions' instances",
+        Justification = "<Pending>"
+    )]
+    public void Test_Text2VecOpenAI_Omits_Unset_Endpoint()
+    {
+        // Arrange
+        var vc = Configure.Vector(
+            "default",
+            v => v.Text2VecOpenAI(model: "text-embedding-3-small")
+        );
+
+        // Act
+        var dto = vc.Vectorizer?.ToDto() ?? default;
+        var json = JsonSerializer.Serialize(
+            dto,
+            new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                DefaultIgnoreCondition = System
+                    .Text
+                    .Json
+                    .Serialization
+                    .JsonIgnoreCondition
+                    .WhenWritingNull,
+                WriteIndented = false,
+            }
+        );
+
+        // Assert
+        Assert.Contains("\"text2vec-openai\"", json);
+        Assert.DoesNotContain("\"endpoint\"", json);
+    }
+
+    /// <summary>
+    /// Tests that Text2VecMorph serializes <c>endpoint</c> when it is set.
+    /// </summary>
+    [Fact]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1869:Cache and reuse 'JsonSerializerOptions' instances",
+        Justification = "<Pending>"
+    )]
+    public void Test_Text2VecMorph_Serializes_Endpoint_When_Set()
+    {
+        // Arrange
+        var vc = Configure.Vector(
+            "default",
+            v => v.Text2VecMorph(model: "morph-embedding-v2", endpoint: "/v2/embeddings")
+        );
+
+        // Act
+        var dto = vc.Vectorizer?.ToDto() ?? default;
+        var json = JsonSerializer.Serialize(
+            dto,
+            new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                DefaultIgnoreCondition = System
+                    .Text
+                    .Json
+                    .Serialization
+                    .JsonIgnoreCondition
+                    .WhenWritingNull,
+                WriteIndented = false,
+            }
+        );
+
+        // Assert
+        Assert.Contains("\"text2vec-morph\"", json);
+        Assert.Contains("\"endpoint\":\"/v2/embeddings\"", json);
+    }
+
+    /// <summary>
+    /// Tests that Text2VecMorph omits <c>endpoint</c> when unset so the server can apply its
+    /// default.
+    /// </summary>
+    [Fact]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1869:Cache and reuse 'JsonSerializerOptions' instances",
+        Justification = "<Pending>"
+    )]
+    public void Test_Text2VecMorph_Omits_Unset_Endpoint()
+    {
+        // Arrange
+        var vc = Configure.Vector("default", v => v.Text2VecMorph(model: "morph-embedding-v2"));
+
+        // Act
+        var dto = vc.Vectorizer?.ToDto() ?? default;
+        var json = JsonSerializer.Serialize(
+            dto,
+            new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                DefaultIgnoreCondition = System
+                    .Text
+                    .Json
+                    .Serialization
+                    .JsonIgnoreCondition
+                    .WhenWritingNull,
+                WriteIndented = false,
+            }
+        );
+
+        // Assert
+        Assert.Contains("\"text2vec-morph\"", json);
+        Assert.DoesNotContain("\"endpoint\"", json);
+    }
 }

--- a/src/Weaviate.Client/Configure/GenerativeConfig.cs
+++ b/src/Weaviate.Client/Configure/GenerativeConfig.cs
@@ -377,6 +377,7 @@ public class GenerativeConfigFactory
     /// <param name="temperature">The temperature.</param>
     /// <param name="topK">The top K.</param>
     /// <param name="topP">The top P.</param>
+    /// <param name="location">The location.</param>
     /// <returns>A <see cref="IGenerativeConfig"/> instance.</returns>
     public IGenerativeConfig GoogleVertex(
         string? apiEndpoint = null,
@@ -387,7 +388,8 @@ public class GenerativeConfigFactory
         string? region = null,
         double? temperature = null,
         int? topK = null,
-        double? topP = null
+        double? topP = null,
+        string? location = null
     ) =>
         new GenerativeConfig.GoogleVertex
         {
@@ -400,6 +402,7 @@ public class GenerativeConfigFactory
             Temperature = temperature,
             TopK = topK,
             TopP = topP,
+            Location = location,
         };
 
     /// <summary>

--- a/src/Weaviate.Client/Configure/VectorizerFactory.cs
+++ b/src/Weaviate.Client/Configure/VectorizerFactory.cs
@@ -799,17 +799,20 @@ public class VectorizerFactory
     /// <param name="baseURL">The base url</param>
     /// <param name="model">The model</param>
     /// <param name="vectorizeCollectionName">The vectorize collection name</param>
+    /// <param name="endpoint">The endpoint</param>
     /// <returns>The vectorizer config</returns>
     public VectorizerConfig Text2VecMorph(
         string? baseURL = null,
         string? model = null,
-        bool? vectorizeCollectionName = null
+        bool? vectorizeCollectionName = null,
+        string? endpoint = null
     ) =>
         new Text2VecMorph
         {
             BaseURL = baseURL,
             Model = model,
             VectorizeCollectionName = vectorizeCollectionName,
+            Endpoint = endpoint,
         };
 
     /// <summary>
@@ -840,6 +843,7 @@ public class VectorizerFactory
     /// <param name="modelVersion">The model version</param>
     /// <param name="type">The type</param>
     /// <param name="vectorizeCollectionName">The vectorize collection name</param>
+    /// <param name="endpoint">The endpoint</param>
     /// <returns>The vectorizer config</returns>
     public VectorizerConfig Text2VecOpenAI(
         string? baseURL = null,
@@ -847,7 +851,8 @@ public class VectorizerFactory
         string? model = null,
         string? modelVersion = null,
         string? type = null,
-        bool? vectorizeCollectionName = null
+        bool? vectorizeCollectionName = null,
+        string? endpoint = null
     ) =>
         new Text2VecOpenAI
         {
@@ -857,6 +862,7 @@ public class VectorizerFactory
             ModelVersion = modelVersion,
             Type = type,
             VectorizeCollectionName = vectorizeCollectionName,
+            Endpoint = endpoint,
         };
 
     /// <summary>

--- a/src/Weaviate.Client/Models/Generative/Providers.cs
+++ b/src/Weaviate.Client/Models/Generative/Providers.cs
@@ -670,6 +670,11 @@ public static class Providers
         public string? Region { get; set; }
 
         /// <summary>
+        /// Gets or sets the Google Vertex AI location.
+        /// </summary>
+        public string? Location { get; set; }
+
+        /// <summary>
         /// Gets or sets the list of base64-encoded images to include in the prompt.
         /// </summary>
         public List<string>? Images { get; set; }

--- a/src/Weaviate.Client/Models/GenerativeConfig.cs
+++ b/src/Weaviate.Client/Models/GenerativeConfig.cs
@@ -647,6 +647,11 @@ public static class GenerativeConfig
         public string? Region { get; set; }
 
         /// <summary>
+        /// Gets or sets the Google Vertex AI location.
+        /// </summary>
+        public string? Location { get; set; }
+
+        /// <summary>
         /// Gets or sets the temperature for controlling randomness in generation.
         /// </summary>
         public double? Temperature { get; set; }

--- a/src/Weaviate.Client/Models/Vectorizer.cs
+++ b/src/Weaviate.Client/Models/Vectorizer.cs
@@ -1147,6 +1147,11 @@ public static class Vectorizer
         public string? BaseURL { get; set; } = null;
 
         /// <summary>
+        /// Gets or sets the value of the endpoint
+        /// </summary>
+        public string? Endpoint { get; set; } = null;
+
+        /// <summary>
         /// Gets or sets the value of the model
         /// </summary>
         public string? Model { get; set; } = null;
@@ -1211,6 +1216,11 @@ public static class Vectorizer
         /// Gets or sets the value of the dimensions
         /// </summary>
         public int? Dimensions { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets the value of the endpoint
+        /// </summary>
+        public string? Endpoint { get; set; } = null;
 
         /// <summary>
         /// Gets or sets the value of the model

--- a/src/Weaviate.Client/PublicAPI.Unshipped.txt
+++ b/src/Weaviate.Client/PublicAPI.Unshipped.txt
@@ -3,13 +3,21 @@ Weaviate.Client.Models.ReplicationOperationState.Integrating = 6 -> Weaviate.Cli
 *REMOVED*Weaviate.Client.VectorizerFactory.Text2VecAWSBedrock(string! region, string! model, bool? vectorizeCollectionName = null) -> Weaviate.Client.Models.VectorizerConfig!
 *REMOVED*Weaviate.Client.VectorizerFactory.Text2VecAWSSagemaker(string! region, string! endpoint, string? targetModel = null, string? targetVariant = null, bool? vectorizeCollectionName = null) -> Weaviate.Client.Models.VectorizerConfig!
 *REMOVED*Weaviate.Client.VectorizerFactory.Text2VecGoogleVertex(string? apiEndpoint = null, string? model = null, string? projectId = null, string? titleProperty = null, int? dimensions = null, string? taskType = null, bool? vectorizeCollectionName = null) -> Weaviate.Client.Models.VectorizerConfig!
+*REMOVED*Weaviate.Client.VectorizerFactory.Text2VecMorph(string? baseURL = null, string? model = null, bool? vectorizeCollectionName = null) -> Weaviate.Client.Models.VectorizerConfig!
+*REMOVED*Weaviate.Client.VectorizerFactory.Text2VecOpenAI(string? baseURL = null, int? dimensions = null, string? model = null, string? modelVersion = null, string? type = null, bool? vectorizeCollectionName = null) -> Weaviate.Client.Models.VectorizerConfig!
 Weaviate.Client.Models.Vectorizer.Text2VecAWS.Dimensions.get -> int?
 Weaviate.Client.Models.Vectorizer.Text2VecAWS.Dimensions.set -> void
 Weaviate.Client.Models.Vectorizer.Text2VecGoogle.Location.get -> string?
 Weaviate.Client.Models.Vectorizer.Text2VecGoogle.Location.set -> void
+Weaviate.Client.Models.Vectorizer.Text2VecMorph.Endpoint.get -> string?
+Weaviate.Client.Models.Vectorizer.Text2VecMorph.Endpoint.set -> void
+Weaviate.Client.Models.Vectorizer.Text2VecOpenAI.Endpoint.get -> string?
+Weaviate.Client.Models.Vectorizer.Text2VecOpenAI.Endpoint.set -> void
 Weaviate.Client.VectorizerFactory.Text2VecAWSBedrock(string! region, string! model, int? dimensions = null, bool? vectorizeCollectionName = null) -> Weaviate.Client.Models.VectorizerConfig!
 Weaviate.Client.VectorizerFactory.Text2VecAWSSagemaker(string! region, string! endpoint, string? targetModel = null, string? targetVariant = null, int? dimensions = null, bool? vectorizeCollectionName = null) -> Weaviate.Client.Models.VectorizerConfig!
 Weaviate.Client.VectorizerFactory.Text2VecGoogleVertex(string? apiEndpoint = null, string? model = null, string? projectId = null, string? titleProperty = null, int? dimensions = null, string? taskType = null, bool? vectorizeCollectionName = null, string? location = null) -> Weaviate.Client.Models.VectorizerConfig!
+Weaviate.Client.VectorizerFactory.Text2VecMorph(string? baseURL = null, string? model = null, bool? vectorizeCollectionName = null, string? endpoint = null) -> Weaviate.Client.Models.VectorizerConfig!
+Weaviate.Client.VectorizerFactory.Text2VecOpenAI(string? baseURL = null, int? dimensions = null, string? model = null, string? modelVersion = null, string? type = null, bool? vectorizeCollectionName = null, string? endpoint = null) -> Weaviate.Client.Models.VectorizerConfig!
 override Weaviate.Client.Models.NamespacesResource.Equals(object? obj) -> bool
 override Weaviate.Client.Models.NamespacesResource.GetHashCode() -> int
 override Weaviate.Client.Models.NamespacesResource.ToString() -> string!

--- a/src/Weaviate.Client/PublicAPI.Unshipped.txt
+++ b/src/Weaviate.Client/PublicAPI.Unshipped.txt
@@ -5,6 +5,7 @@ Weaviate.Client.Models.ReplicationOperationState.Integrating = 6 -> Weaviate.Cli
 *REMOVED*Weaviate.Client.VectorizerFactory.Text2VecGoogleVertex(string? apiEndpoint = null, string? model = null, string? projectId = null, string? titleProperty = null, int? dimensions = null, string? taskType = null, bool? vectorizeCollectionName = null) -> Weaviate.Client.Models.VectorizerConfig!
 *REMOVED*Weaviate.Client.VectorizerFactory.Text2VecMorph(string? baseURL = null, string? model = null, bool? vectorizeCollectionName = null) -> Weaviate.Client.Models.VectorizerConfig!
 *REMOVED*Weaviate.Client.VectorizerFactory.Text2VecOpenAI(string? baseURL = null, int? dimensions = null, string? model = null, string? modelVersion = null, string? type = null, bool? vectorizeCollectionName = null) -> Weaviate.Client.Models.VectorizerConfig!
+*REMOVED*Weaviate.Client.GenerativeConfigFactory.GoogleVertex(string? apiEndpoint = null, int? maxOutputTokens = null, string? model = null, string? projectId = null, string? endpointId = null, string? region = null, double? temperature = null, int? topK = null, double? topP = null) -> Weaviate.Client.Models.IGenerativeConfig!
 Weaviate.Client.Models.Vectorizer.Text2VecAWS.Dimensions.get -> int?
 Weaviate.Client.Models.Vectorizer.Text2VecAWS.Dimensions.set -> void
 Weaviate.Client.Models.Vectorizer.Text2VecGoogle.Location.get -> string?
@@ -13,6 +14,11 @@ Weaviate.Client.Models.Vectorizer.Text2VecMorph.Endpoint.get -> string?
 Weaviate.Client.Models.Vectorizer.Text2VecMorph.Endpoint.set -> void
 Weaviate.Client.Models.Vectorizer.Text2VecOpenAI.Endpoint.get -> string?
 Weaviate.Client.Models.Vectorizer.Text2VecOpenAI.Endpoint.set -> void
+Weaviate.Client.Models.GenerativeConfig.GoogleVertex.Location.get -> string?
+Weaviate.Client.Models.GenerativeConfig.GoogleVertex.Location.set -> void
+Weaviate.Client.Models.Generative.Providers.GoogleVertex.Location.get -> string?
+Weaviate.Client.Models.Generative.Providers.GoogleVertex.Location.set -> void
+Weaviate.Client.GenerativeConfigFactory.GoogleVertex(string? apiEndpoint = null, int? maxOutputTokens = null, string? model = null, string? projectId = null, string? endpointId = null, string? region = null, double? temperature = null, int? topK = null, double? topP = null, string? location = null) -> Weaviate.Client.Models.IGenerativeConfig!
 Weaviate.Client.VectorizerFactory.Text2VecAWSBedrock(string! region, string! model, int? dimensions = null, bool? vectorizeCollectionName = null) -> Weaviate.Client.Models.VectorizerConfig!
 Weaviate.Client.VectorizerFactory.Text2VecAWSSagemaker(string! region, string! endpoint, string? targetModel = null, string? targetVariant = null, int? dimensions = null, bool? vectorizeCollectionName = null) -> Weaviate.Client.Models.VectorizerConfig!
 Weaviate.Client.VectorizerFactory.Text2VecGoogleVertex(string? apiEndpoint = null, string? model = null, string? projectId = null, string? titleProperty = null, int? dimensions = null, string? taskType = null, bool? vectorizeCollectionName = null, string? location = null) -> Weaviate.Client.Models.VectorizerConfig!

--- a/src/Weaviate.Client/gRPC/Search.Builders.cs
+++ b/src/Weaviate.Client/gRPC/Search.Builders.cs
@@ -372,6 +372,7 @@ internal partial class WeaviateGrpcClient
                     ProjectId = a.ProjectId ?? string.Empty,
                     EndpointId = a.EndpointId ?? string.Empty,
                     Region = a.Region ?? string.Empty,
+                    Location = a.Location ?? string.Empty,
                     Images = a.Images != null ? new V1.TextArray { Values = { a.Images } } : null,
                     ImageProperties =
                         a.ImageProperties != null
@@ -397,6 +398,9 @@ internal partial class WeaviateGrpcClient
                     ProjectId = string.Empty,
                     EndpointId = string.Empty,
                     Region = string.Empty,
+                    // Location (Vertex AI region) is not applicable to the Gemini
+                    // (generative-language) API; left empty like Region above.
+                    Location = string.Empty,
                     Images = a.Images != null ? new V1.TextArray { Values = { a.Images } } : null,
                     ImageProperties =
                         a.ImageProperties != null

--- a/src/Weaviate.Client/gRPC/proto/v1/generative.proto
+++ b/src/Weaviate.Client/gRPC/proto/v1/generative.proto
@@ -165,6 +165,7 @@ message GenerativeGoogle{
   optional string region = 12;
   optional TextArray images = 13;
   optional TextArray image_properties = 14;
+  optional string location = 15;
 }
 
 message GenerativeDatabricks{


### PR DESCRIPTION
- Add optional `endpoint` to **text2vec-openai** and **text2vec-morph** module configs, serialized as `endpoint` and omitted when unset (server default `/v1/embeddings`). Closes #350. Matches the open Python implementation (weaviate-python-client#2090).
- Add optional `location` to **generative-google** on both surfaces: collection `moduleConfig` (`GoogleVertex`) and the query-time generative provider (`Providers.GoogleVertex`), serialized as `location` (server default `us-central1`). Closes #351. Python's twin (weaviate-python-client#2073) is still open, so key names were taken from core (`class_settings.go`) and the proto.
- `generative.proto`: adds `optional string location = 15` to `GenerativeGoogle`, verbatim from the server v1.38.4 tag (the field was missing from the vendored proto).
- 7 new unit tests (serialize-when-set / omit-when-unset per surface); suite green (863 + 34, 0 failed); public-API analyzer baseline unchanged.